### PR TITLE
Display of percentage after brightness icon is now optional

### DIFF
--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -9,9 +9,9 @@ This widget represents current brightness level.
 Firstly you need to get the current brightness level. There are two options:
 
  - using `xbacklight` command (depending on your video card (I guess) it may or may not work)
- 
+
     To check if it works install xbackligth and check if it works:
- 
+
     ```bash
     sudo apt-get install xbacklight
     xbackligth -get
@@ -20,7 +20,7 @@ Firstly you need to get the current brightness level. There are two options:
     If there is no output it means that it doesn't work, but there is a second option:
 
  - using `light` command
- 
+
     Install it from this git repo: [github.com/haikarainen/light](https://github.com/haikarainen/light) and check if it works but running
 
     ```bash
@@ -42,8 +42,16 @@ s.mywibox:setup {
 ...
 { -- Right widgets
 ...
-brightness_widget
+brightness_widget()
 ```
+If you want to display the percentage as text to the right of the icon you can change ```brightness_widget()``` to the following:
+```
+...
+{ -- Right widgets
+...
+brightness_widget(true)
+```
+
 
 In order to change brightness by shortcuts you can add them to the `globalkeys` table in the **rc.lua**:
 

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -17,11 +17,14 @@ local brightness_icon = wibox.widget {
     layout = wibox.container.margin(brightness_icon, 0, 0, 3)
 }
 
-brightness_widget = wibox.widget {
-    brightness_icon,
-    brightness_text,
-    layout = wibox.layout.fixed.horizontal,
-}
+function brightness_widget(show_percentage)
+   local widget_contents = {brightness_icon}
+   if show_percentage then
+      table.insert(widget_contents, brightness_text)
+   end
+   widget_contents.layout = wibox.layout.fixed.horizontal
+   return wibox.widget(widget_contents)
+end
 
 watch(
     get_brightness_cmd, 1,


### PR DESCRIPTION
I modified the code slightly to make the percentage optional while still making it easy to add the widget.
Let me know if you think it is a good idea or not. I am planning on adding similar to the volume and battery widget as well :)

P.s. My emacs customizations is playing tricks again, editing some lines that had trailing spaces. If you want I can make sure these edits don't happen in the future, but if it is not problem I'll just let my emacs do its job.