### PR TITLE
Fix batteryarc_widget require statement

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -29,7 +29,7 @@ which means that you need to copy the code above and paste it in your **theme.lu
 Clone repo, include widget and use it in **rc.lua**:
 
 ```lua
-require("volumearc")
+local batteryarc_widget = require("awesome-wm-widgets.batteryarc-widget.batteryarc")
 ...
 s.mytasklist, -- Middle widget
 	{ -- Right widgets


### PR DESCRIPTION
While trying out the widget set I noticed that the installation docs for this widget weren't correct.  The `require` statement now works as expected and it matches the pattern used in other installation docs mentioned in the repo.

Hope this helps!