### PR TITLE
Fix cpu-widget color switch

### DIFF
--- a/cpu-widget/cpu-widget.lua
+++ b/cpu-widget/cpu-widget.lua
@@ -11,6 +11,7 @@
 local watch = require("awful.widget.watch")
 local wibox = require("wibox")
 local beautiful = require("beautiful")
+local gears = require("gears")
 
 local cpugraph_widget = wibox.widget {
     max_value = 100,
@@ -38,8 +39,7 @@ watch([[bash -c "cat /proc/stat | grep '^cpu '"]], 1,
         local diff_total = total - total_prev
         local diff_usage = (1000 * (diff_total - diff_idle) / diff_total + 5) / 10
 
-        widget:set_color(diff_usage > 80 and beautiful.widget_red
-                                          or beautiful.widget_main_color)
+        widget.color = diff_usage > 80 and gears.color("red") or beautiful.get().bg_focus
 
         widget:add_value(diff_usage)
 


### PR DESCRIPTION
The cpu widget was always red in my case.  I did not find the used `set_color` function in [`wibox.widget`](https://awesomewm.org/apidoc/classes/wibox.widget.html) class documentation.  Instead there is [`color`](https://awesomewm.org/apidoc/classes/wibox.widget.graph.html#wibox.widget.graph.color) property in the `wibox.widget.graph` class which can be used to change the graph color.