### PR TITLE
destroy notification prior making new one

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -35,6 +35,7 @@ local notification
 local function show_battery_status()
     awful.spawn.easy_async([[bash -c 'acpi']],
         function(stdout, _, _, _)
+            naughty.destroy(notification)
             notification = naughty.notify{
                 text =  stdout,
                 title = "Battery status",


### PR DESCRIPTION
Sometimes the `mouse::leave` signal doesn't make it on time to destroy the old notification properly. 

![image](https://user-images.githubusercontent.com/1833840/54989866-b5d9ba80-4fb9-11e9-9d10-c5e4ccc3f837.png)