### PR TITLE
Make ram-widget compatible for non-english OS

### DIFF
--- a/ram-widget/ram-widget.lua
+++ b/ram-widget/ram-widget.lua
@@ -42,7 +42,7 @@ local function getPercentage(value)
     return math.floor(value / (total+total_swap) * 100 + 0.5) .. '%'
 end
 
-watch('bash -c "free | grep -z Mem.*Swap.*"', 1,
+watch('bash -c "LANGUAGE=en_US.UTF-8 free | grep -z Mem.*Swap.*"', 1,
     function(widget, stdout, stderr, exitreason, exitcode)
         total, used, free, shared, buff_cache, available, total_swap, used_swap, free_swap =
             stdout:match('(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*Swap:%s*(%d+)%s*(%d+)%s*(%d+)')


### PR DESCRIPTION
The output of the free command is grep'ed while assuming english column names. This grep fails when given non-english localization.
Setting the LANGUAGE variable inside the bash invocation solves this problem.