### PR TITLE
Fixed buggy spawning of os.time().

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -109,7 +109,7 @@ watch("acpi -i", 10,
             batteryType = "battery-empty%s-symbolic"
             if status ~= 'Charging' and os.difftime(os.time(), last_battery_check) > 300 then
                 -- if 5 minutes have elapsed since the last warning
-                last_battery_check = time()
+                last_battery_check = os.time()
 
                 show_battery_warning()
             end


### PR DESCRIPTION
A little typo in battery-widget: call os.time() instead of time(), which ends in a spawn error.

Thanks by the way for these beautiful widgest. This gave me a kickstart on own customizations.