### PR TITLE
add options to show temperature in both units

### DIFF
--- a/secrets.lua
+++ b/secrets.lua
@@ -5,6 +5,15 @@
 -- @copyright 2019 Pavel Makhov
 --------------------------------------------
 
+local function getenv_bool(var_name, default_val)
+    val = os.getenv(var_name)
+    if val ~= nil then
+        return val:lower() == 'true'
+    else
+        return default_val
+    end
+end
+
 local secrets = {
     -- Yandex.Translate API key - https://tech.yandex.com/translate/
     translate_widget_api_key = os.getenv('AWW_TRANSLATE_API_KEY') or 'API_KEY',
@@ -12,7 +21,9 @@ local secrets = {
     -- OpenWeatherMap API key - https://openweathermap.org/appid
     weather_widget_api_key = os.getenv('AWW_WEATHER_API_KEY') or 'API_KEY',
     weather_widget_city = os.getenv('AWW_WEATHER_CITY') or 'Montreal,ca',
-    weather_widget_units = os.getenv('AWW_WEATHER_UNITS') or 'metric' -- for celsius, or 'imperial' for fahrenheit
+    weather_widget_units = os.getenv('AWW_WEATHER_UNITS') or 'metric', -- for celsius, or 'imperial' for fahrenheit
+    weather_both_temp_units_widget = getenv_bool('AWW_WEATHER_BOTH_UNITS_WIDGET', false), -- on widget, if true shows "22 C (72 F)", instead of only "22 C"
+    weather_both_temp_units_popup = getenv_bool('AWW_WEATHER_BOTH_UNITS_POPUP', true) -- in the popup, if true shows "22.3 C (72.2 F)" instead of only "22.3 C"
 }
 
 return secrets


### PR DESCRIPTION
Separate options for the widget itself, and in the popup.

Also note that this changes the precision slightly:
- on the widget itself: now uses string formatting to round, instead of removing the decimal
- on the popup: rounds to 1 decimal place in popup (was showing 2 decimal places before)

And the width of the weather popup is increased from 200 to 210 if the new
`weather_both_temp_units_popup` setting is set to true. This is to make room for
the case where the temperature is greater than 100 degrees Fahrenheit, because
the 3 digits caused line wrapping on my screen.
