### PR TITLE
 volume widget support for amixer with no device specified

### DIFF
--- a/secrets.lua
+++ b/secrets.lua
@@ -6,6 +6,9 @@
 --------------------------------------------
 
 local secrets = {
+    -- See volume-widget/README.md
+    volume_audio_controller = os.getenv('AWW_VOLUME_CONTROLLER') or 'pulse', -- 'pulse' or 'alsa_only'
+
     -- Yandex.Translate API key - https://tech.yandex.com/translate/
     translate_widget_api_key = os.getenv('AWW_TRANSLATE_API_KEY') or 'API_KEY',
 

--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -31,6 +31,31 @@ s.mytasklist, -- Middle widget
  sudo sed -i 's/bebebe/ed4737/g' ./audio-volume-muted-symbolic_red.svg 
  ```
 
+### Pulse or ALSA only
+
+Try running this command:
+
+```amixer -D pulse sget Master```
+
+If that prints something like this, then the default setting of 'pulse' is probably fine:
+```
+Simple mixer control 'Master',0
+  Capabilities: pvolume pvolume-joined pswitch pswitch-joined
+  Playback channels: Mono
+  Limits: Playback 0 - 64
+  Mono: Playback 64 [100%] [0.00dB] [on]
+
+```
+
+If it prints something like this:
+```
+$ amixer -D pulse sget Master
+ALSA lib pulse.c:243:(pulse_connect) PulseAudio: Unable to connect: Connection refused
+
+amixer: Mixer attach pulse error: Connection refused
+```
+then try setting the environment variable `AWW_VOLUME_CONTROLLER` to `alsa_only`.
+
 ## Control volume
 
 To mute/unmute click on the widget. To increase/decrease volume scroll up or down when mouse cursor is over the widget.

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -13,12 +13,21 @@ local wibox = require("wibox")
 local watch = require("awful.widget.watch")
 local spawn = require("awful.spawn")
 
+local secrets = require("awesome-wm-widgets.secrets")
+
 local path_to_icons = "/usr/share/icons/Arc/status/symbolic/"
 
-local GET_VOLUME_CMD = 'amixer -D pulse sget Master'
-local INC_VOLUME_CMD = 'amixer -D pulse sset Master 5%+'
-local DEC_VOLUME_CMD = 'amixer -D pulse sset Master 5%-'
-local TOG_VOLUME_CMD = 'amixer -D pulse sset Master toggle'
+if secrets.volume_audio_controller == 'pulse' then
+	device_arg = '-D pulse'
+else
+	device_arg = ''
+end
+
+local GET_VOLUME_CMD = 'amixer ' .. device_arg .. ' sget Master'
+local INC_VOLUME_CMD = 'amixer ' .. device_arg .. ' sset Master 5%+'
+local DEC_VOLUME_CMD = 'amixer ' .. device_arg .. ' sset Master 5%-'
+local TOG_VOLUME_CMD = 'amixer ' .. device_arg .. ' sset Master toggle'
+
 
 local volume_widget = wibox.widget {
     {

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -17,6 +17,7 @@ local secrets = require("awesome-wm-widgets.secrets")
 
 local path_to_icons = "/usr/share/icons/Arc/status/symbolic/"
 
+local device_arg
 if secrets.volume_audio_controller == 'pulse' then
 	device_arg = '-D pulse'
 else


### PR DESCRIPTION
This works on my setup without having `pulseaudio` installed.

I don't know much about this, I just found that your widget worked when I removed `-D pulse`, so I thought that I'd share it. I'm running archlinux and I see that I have only these packages:

```
$ pacman -Q | grep -i 'alsa\|pulse\|audio'
alsa-lib 1.1.9-2
alsa-plugins 1.1.9-2
alsa-utils 1.1.9-1
lib32-alsa-lib 1.1.9-1
lib32-alsa-plugins 1.1.9-1
libpulse 12.2-2
portaudio 1:19.6.0-6
zita-alsa-pcmi 0.3.2-1
```

There is a `pulseaudio` package available, but I don't have it installed.