### PR TITLE
Use the correct parameter in the installation example for batteryarc-…

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -49,7 +49,7 @@ s.mytasklist, -- Middle widget
         --[[or customized]]
         batteryarc_widget({
             show_current_level = true,
-            thickness = '1',
+            arc_thickness = '1',
         }),
 	}
 	...


### PR DESCRIPTION
Use the correct parameter 'arc_thickness' instead of 'thickness'.