### PR TITLE
Fix arc_thickness variable name

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -27,7 +27,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `main_color` | `beautiful.fg_color` | Color of the text with the current charge level and the arc |
 | `low_level_color` | #e53935 | Arc color when battery charge is less that 15% |
 | `medium_level_color` | #c0ca33 |  Arc color when battery charge is between 15% and 40% |
-| `charging` | `beautiful.fg_color` |  Color of the circle inside the arc when charging  |
+| `charging` | `#43a047` |  Color of the circle inside the arc when charging  |
 | `warning_msg_title` | _Huston, we have a problem_ | Title of the warning popup |
 | `warning_msg_text` | _Battery is dying_ | Text of the warning popup |
 | `warning_msg_position` | `bottom_right` | Position of the warning popup |

--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -23,7 +23,7 @@ local function worker(args)
     local args = args or {}
 
     local font = args.font or 'Play 6'
-    local arc_thickness = args.thickness or 2
+    local arc_thickness = args.arc_thickness or 2
     local show_current_level = args.show_current_level or false
 
     local main_color = args.main_color or beautiful.fg_color


### PR DESCRIPTION
The arc_thickness variable name was named tickness internally. Renamed `thickness` to `arc_thickness`.

Updated the name of the charging default color in the README.