### PR TITLE
Remove extra branch that broke when "rate information unavailable"

### DIFF
--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -68,10 +68,8 @@ local function worker(args)
                 local battery_info = {}
                 local capacities = {}
                 for s in stdout:gmatch("[^\r\n]+") do
-                    local status, charge_str, time = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?.*')
-                    if string.match(s, 'rate information') then
-                        -- ignore such line
-                    elseif status ~= nil then
+                    local status, charge_str, time = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?(.*)')
+                    if status ~= nil then
                         table.insert(battery_info, { status = status, charge = tonumber(charge_str) })
                     else
                         local cap_str = string.match(s, '.+:.+last full capacity (%d+)')


### PR DESCRIPTION
Fix issues caused by the "rate information unavailable" text that shows up after the battery percentage. This caused the charge_str and status to show up as nil which caused the notification to show up periodically.

Example output:
```
Battery 0: Full, 100%, rate information unavailable
Battery 0: design capacity 8508 mAh, last full capacity 8067 mAh = 94%
```
Fixes #95 
Fixes #75 
