### PR TITLE
Make backgrounds theme-able

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -25,6 +25,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `arc_thickness` | 2 | Thickness of the arc |
 | `show_current_level`| false | Show current charge level |
 | `main_color` | `beautiful.fg_color` | Color of the text with the current charge level and the arc |
+| `bg_color` | `#ffffff11` | Color of the charge level background |
 | `low_level_color` | #e53935 | Arc color when battery charge is less that 15% |
 | `medium_level_color` | #c0ca33 |  Arc color when battery charge is between 15% and 40% |
 | `charging` | `#43a047` |  Color of the circle inside the arc when charging  |

--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -27,6 +27,7 @@ local function worker(args)
     local show_current_level = args.show_current_level or false
 
     local main_color = args.main_color or beautiful.fg_color
+    local bg_color = args.bg_color or '#ffffff11'
     local low_level_color = args.low_level_color or '#e53935'
     local medium_level_color = args.medium_level_color or '#c0ca33'
     local charging_color = args.charging_color or '#43a047'
@@ -54,7 +55,7 @@ local function worker(args)
         start_angle = 4.71238898, -- 2pi*3/4
         forced_height = 18,
         forced_width = 18,
-        bg = "#ffffff11",
+        bg = bg_color,
         paddings = 2,
         widget = wibox.container.arcchart
     }

--- a/brightnessarc-widget/README.md
+++ b/brightnessarc-widget/README.md
@@ -12,6 +12,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `inc_brightness_cmd` | `light -A 5` | Increase brightness |
 | `dec_brightness_cmd` | `light -U 5`| Decrease brightness |
 | `color` | `beautiful.fg_color` | Color of the arc |
+| `bg_color` | `#ffffff11` | Color of the arc's background |
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
 
 ### Example:

--- a/brightnessarc-widget/brightnessarc.lua
+++ b/brightnessarc-widget/brightnessarc.lua
@@ -28,6 +28,7 @@ local function worker(args)
     local inc_brightness_cmd = args.inc_brightness_cmd or INC_BRIGHTNESS_CMD
     local dec_brightness_cmd = args.dec_brightness_cmd or DEC_BRIGHTNESS_CMD
     local color = args.color or beautiful.fg_color
+    local bg_color = args.bg_color or '#ffffff11'
     local path_to_icon = args.path_to_icon or PATH_TO_ICON
 
     local icon = {
@@ -44,7 +45,7 @@ local function worker(args)
         start_angle = 4.71238898, -- 2pi*3/4
         forced_height = 18,
         forced_width = 18,
-        bg = "#ffffff11",
+        bg = bg_color,
         paddings = 2,
         colors = {color},
         widget = wibox.container.arcchart

--- a/volumearc-widget/README.md
+++ b/volumearc-widget/README.md
@@ -16,6 +16,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `main_color` | `beautiful.fg_normal` | Color of the arc |
+| `bg_color` | `#ffffff11` | Color of the arc's background |
 | `mute_color` | `beautiful.fg_urgent` | Color of the arc when mute |
 | `path_to_icon` | /usr/share/icons/Arc/status/symbolic/audio-volume-muted-symbolic.svg | Path to the icon |
 | `thickness` | 2 | The arc thickness |

--- a/volumearc-widget/volumearc.lua
+++ b/volumearc-widget/volumearc.lua
@@ -28,6 +28,7 @@ local function worker(args)
     local args = args or {}
 
     local main_color = args.main_color or beautiful.fg_color
+    local bg_color = args.bg_color or '#ffffff11'
     local mute_color = args.mute_color or beautiful.fg_urgent
     local path_to_icon = args.path_to_icon or PATH_TO_ICON
     local thickness = args.thickness or 2
@@ -52,7 +53,7 @@ local function worker(args)
         start_angle = 4.71238898, -- 2pi*3/4
         forced_height = height,
         forced_width = height,
-        bg = "#ffffff11",
+        bg = bg_color,
         paddings = 2,
         widget = wibox.container.arcchart
     }

--- a/volumebar-widget/README.md
+++ b/volumebar-widget/README.md
@@ -16,6 +16,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `main_color` | `beautiful.fg_normal` | Color of the bar |
+| `bg_color` | `#ffffff11` | Color of the bar's background |
 | `mute_color` | `beautiful.fg_urgent` | Color of the bar when mute |
 | `width` | 50 | The bar width |
 | `shape` | `bar` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |

--- a/volumebar-widget/volumebar.lua
+++ b/volumebar-widget/volumebar.lua
@@ -28,6 +28,7 @@ local function worker(args)
 
     local main_color = args.main_color or beautiful.fg_normal
     local mute_color = args.mute_color or beautiful.fg_urgent
+    local bg_color = args.bg_color or '#ffffff11'
     local width = args.width or 50
     local shape = args.shape or 'bar'
     local margins = args.margins or 10
@@ -41,7 +42,7 @@ local function worker(args)
         max_value = 1,
         forced_width = width,
         color = main_color,
-        background_color = '#ffffff11',
+        background_color = bg_color,
         shape = gears.shape[shape],
         margins = {
             top = margins,


### PR DESCRIPTION
Fixes visibility on light themes

Affects widgets:
- `batteryarc`
- `brightnessarc`
- `volumearc`
- `volumebar`

Fixes #109