### PR TITLE
volume: fix error on mouse leave

### DIFF
--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -57,7 +57,7 @@ local function worker(args)
         end
     }
 
-    local notification = {}
+    local notification
     local volume_icon_name="audio-volume-high-symbolic"
 
     local function get_notification_text(txt)


### PR DESCRIPTION
naughty destroy is expecting a nil argument or a real notification,
using `{}` triggers an error on destroy
Fix: #112 
