### PR TITLE
fix - cpu-widget.lua: update pattern match for comm/Name

### DIFF
--- a/cpu-widget/cpu-widget.lua
+++ b/cpu-widget/cpu-widget.lua
@@ -175,7 +175,7 @@ local function worker(args)
                     else
                         if is_update == true then
 
-                            local pid, comm, cpu, mem, cmd = line:match('(%d+)%s+(%w+%p*%w*)%s+([%d.]+)%s+([%d.]+)%s+(.+)')
+                            local pid, comm, cpu, mem, cmd = line:match('(%d+)%s+([%w%p?%s]+)%s+([%d.]+)%s+([%d.]+)%s+(.+)')
                             if pid == nil then
                                 pid = 'PID'
                                 comm = 'Name'

--- a/cpu-widget/cpu-widget.lua
+++ b/cpu-widget/cpu-widget.lua
@@ -175,16 +175,17 @@ local function worker(args)
                     else
                         if is_update == true then
 
-                            local pid, comm, cpu, mem, cmd = line:match('(%d+)%s+(%w+)%s+([%d.]+)%s+([%d.]+)%s+(.+)')
-                            cmd = string.sub(cmd,0, 300)
-                            cmd = cmd .. '...'
+                            local pid, comm, cpu, mem, cmd = line:match('(%d+)%s+(%w+%p*%w*)%s+([%d.]+)%s+([%d.]+)%s+(.+)')
                             if pid == nil then
                                 pid = 'PID'
                                 comm = 'Name'
                                 cpu = '%CPU'
                                 mem = '%MEM'
-
+                                cmd = 'CMD'
                             end
+
+                            cmd = string.sub(cmd,0, 300)
+                            cmd = cmd .. '...'
 
                             local row = wibox.widget {
                                 {


### PR DESCRIPTION
This PR fixes a bug where the widget crashes if one of the top processes has a "-" in it's name.
Example `signal-desktop`
Since this isn't matched by the pattern `cmd` ends up being `nil` causing the string.sub call to bomb out.
```
awesome: Error during a protected call: awesome-wm-widgets/cpu-widget/cpu-widget.lua:179:
    bad argument #1 to 'sub' (string expected, got nil)
```