### PR TITLE
Display the notification on the current screen

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -84,6 +84,7 @@ local function worker(args)
                 position = position,
                 timeout = 5, hover_timeout = 0.5,
                 width = 200,
+                screen = mouse.screen
             }
         end
         )
@@ -109,6 +110,7 @@ local function worker(args)
             bg = "#F06060",
             fg = "#EEE9EF",
             width = 300,
+            screen = mouse.screen
         }
     end
     local last_battery_check = os.time()

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -81,6 +81,7 @@ local function notif(msg, keep)
             position = volume.position,
             timeout = keep and 0 or 2, hover_timeout = 0.5,
             width = 200,
+            screen = mouse.screen
         }
     end
 end

--- a/weather-widget/weather.lua
+++ b/weather-widget/weather.lua
@@ -210,6 +210,7 @@ local function worker(args)
                 '<b>Wind:</b> ' .. resp.wind.speed .. 'm/s (' .. to_direction(resp.wind.deg) .. ')',
             timeout = 5, hover_timeout = 10,
             position = position,
+            screen = mouse.screen,
             width = (both_units_popup == true and 210 or 200)
         }
     end)


### PR DESCRIPTION
When you use several screens, the notifications are displayed on the main screen.
For mouseover or click notifications this is very strange.