### PR TITLE
Fix ambiguity in some READMEs

### DIFF
--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -55,7 +55,7 @@ First you need to get the current brightness level. There are two options:
 Then clone this repo under **~/.config/awesome/**:
 
 ```bash
-git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/
+git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/awesome-wm-widgets
 ```
 
 Require widget at the beginning of **rc.lua**:

--- a/brightnessarc-widget/README.md
+++ b/brightnessarc-widget/README.md
@@ -57,7 +57,7 @@ First you need to get the current brightness level. There are two options:
 Then clone this repo under **~/.config/awesome/**:
 
 ```bash
-git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/
+git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/awesome-wm-widgets
 ```
 
 Require widget at the beginning of **rc.lua**:

--- a/run-shell-3/README.md
+++ b/run-shell-3/README.md
@@ -17,13 +17,13 @@ Blurs / pixelates background and shows widget with run prompt:
 1. Clone this repo under **~/.config/awesome/**:
 
     ```bash
-    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/
+    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/awesome-wm-widgets
     ```
 
 1. Require widget at the beginning of **rc.lua**:
 
     ```lua
-    local run_shell = require("awesome-wm-widgets.run_shell.run_shell")
+    local run_shell = require("awesome-wm-widgets.run-shell-3.run-shell")
     ```
 
 1. Use it (don't forget to comment out the default prompt):

--- a/run-shell/README.md
+++ b/run-shell/README.md
@@ -9,7 +9,7 @@ Run prompt which is put inside a widget:
 1. Clone this repo under **~/.config/awesome/**:
 
     ```bash
-    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/
+    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/awesome-wm-widgets
     ```
 
 1. Require widget at the beginning of **rc.lua**:

--- a/run-shell/README.md
+++ b/run-shell/README.md
@@ -15,7 +15,7 @@ Run prompt which is put inside a widget:
 1. Require widget at the beginning of **rc.lua**:
 
     ```lua
-    local run_shell = require("awesome-wm-widgets.run_shell.run_shell")
+    local run_shell = require("awesome-wm-widgets.run-shell.run-shell")
     ```
 
 1. Use it (don't forget to comment out the default prompt):

--- a/volumearc-widget/README.md
+++ b/volumearc-widget/README.md
@@ -46,13 +46,13 @@ The config above results in the following widget:
 1. Clone this repo under **~/.config/awesome/**
 
     ```bash
-    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/
+    git clone https://github.com/streetturtle/awesome-wm-widgets.git ~/.config/awesome/awesome-wm-widgets
     ```
 
 1. Require volumearc widget at the beginning of **rc.lua**:
 
 ```lua
-require("volumearc")
+local volumearc_widget = require("awesome-wm-widgets.volumearc-widget.volumearc")
 ...
 s.mytasklist, -- Middle widget
 	{ -- Right widgets


### PR DESCRIPTION
Sorry, this PR is a bit messy - just wanted to quickly fix some READMEs which were a bit weird e.g. just setting require() without making variables and having underscores when hyphens are needed. 

I didn't look at all of the widgets, so there might be more little mistakes like these.

Sorry if I've done this all wrong - this is my first PR :D