### PR TITLE
FIx parameter error on readme

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -29,7 +29,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `bg_color` | `#ffffff11` | Color of the charge level background |
 | `low_level_color` | `#e53935` | Arc color when battery charge is less that 15% |
 | `medium_level_color` | `#c0ca33` |  Arc color when battery charge is between 15% and 40% |
-| `charging` | `#43a047` |  Color of the circle inside the arc when charging  |
+| `charging_color` | `#43a047` |  Color of the circle inside the arc when charging  |
 | `warning_msg_title` | _Huston, we have a problem_ | Title of the warning popup |
 | `warning_msg_text` | _Battery is dying_ | Text of the warning popup |
 | `warning_msg_position` | `bottom_right` | Position of the warning popup |


### PR DESCRIPTION
This parameter is missing the `_color` postfix.
Just a quick refactor, to save time debugging the widget