### PR TITLE
Special-case a curl connection timeout @ ⛅ widget

### DIFF
--- a/weather-widget/weather.lua
+++ b/weather-widget/weather.lua
@@ -395,7 +395,10 @@ local function worker(args)
             if not warning_shown then
                 if (
                     stderr ~= 'curl: (52) Empty reply from server' and
-                    stderr ~= 'curl: (28) Failed to connect to api.openweathermap.org port 443: Connection timed out'
+                    stderr ~= 'curl: (28) Failed to connect to api.openweathermap.org port 443: Connection timed out' and
+                    stderr:find(
+                        '^curl: %(18%) transfer closed with %d+ bytes remaining to read$'
+                    ) ~= nil
                 ) then
                     show_warning(stderr)
                 end

--- a/weather-widget/weather.lua
+++ b/weather-widget/weather.lua
@@ -393,7 +393,10 @@ local function worker(args)
     local function update_widget(widget, stdout, stderr)
         if stderr ~= '' then
             if not warning_shown then
-                if stderr ~= 'curl: (52) Empty reply from server' then
+                if (
+                    stderr ~= 'curl: (52) Empty reply from server' and
+                    stderr ~= 'curl: (28) Failed to connect to api.openweathermap.org port 443: Connection timed out'
+                ) then
                     show_warning(stderr)
                 end
                 warning_shown = true


### PR DESCRIPTION
This is a follow-up for #169.

I've got a new `curl: (28) Failed to connect to api.openweathermap.org port 443: Connection timed out` error and it's annoying too.