### PR TITLE
Remove doubled temperature line

### DIFF
--- a/weather-widget/weather.lua
+++ b/weather-widget/weather.lua
@@ -370,8 +370,6 @@ local function worker(args)
             local count = #self
             for i = 0, count do self[i]=nil end
 
-
-            table.insert(self, temp_below)
             table.insert(self, wibox.widget{
                 {
                     hourly_forecast_graph,


### PR DESCRIPTION
this line was doubled, but was barely noticable because (in my case, and the demo case) the text almost matched the background.

![before](https://user-images.githubusercontent.com/9095245/90310536-65645380-df46-11ea-8bd9-8b6a6b18ea2b.png) ![after](https://user-images.githubusercontent.com/9095245/90310538-67c6ad80-df46-11ea-8100-fefc14e32a2b.png)
