### PR TITLE
Fixed trouble with state "Not charging"

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -18,6 +18,7 @@ local dpi = require('beautiful').xresources.apply_dpi
 -- acpi sample outputs
 -- Battery 0: Discharging, 75%, 01:51:38 remaining
 -- Battery 0: Charging, 53%, 00:57:43 until charged
+-- Battery 0: Not charging, 98%
 
 local HOME = os.getenv("HOME")
 
@@ -121,7 +122,7 @@ local function worker(args)
         local battery_info = {}
         local capacities = {}
         for s in stdout:gmatch("[^\r\n]+") do
-            local status, charge_str, time = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?(.*)')
+            local status, charge_str, time = string.match(s, '.+: ([a-zA-Z0-9 ]+), (%d?%d?%d)%%,?(.*)')
             if status ~= nil then
                 table.insert(battery_info, {status = status, charge = tonumber(charge_str)})
             else


### PR DESCRIPTION
Acpi can give us one more state:

> Battery 0: Not charging, 98%

And for this state regex will not work. 
I replaced regex from ".+: (%a+), (%d?%d?%d)%%,?(.*)" to ".+: ([a-zA-Z0-9 ]+), (%d?%d?%d)%%,?(.*)" (this regex include space symbol).