### PR TITLE
Add customizable refresh timeouts to most widgets

### DIFF
--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -28,6 +28,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `margin_left`|0| The left margin of the widget|
 | `display_notification` | `false` | Display a notification on mouseover |
 | `notification_position` | `top_right` | The notification position |
+| `timeout` | 10 | How often in seconds the widget refreshes |
 | `warning_msg_title` | _Huston, we have a problem_ | Title of the warning popup |
 | `warning_msg_text` | _Battery is dying_ | Text of the warning popup |
 | `warning_msg_position` | `bottom_right` | Position of the warning popup |

--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -33,6 +33,7 @@ local function worker(args)
 
     local display_notification = args.display_notification or false
     local position = args.notification_position or "top_right"
+    local timeout = args.timeout or 10
 
     local warning_msg_title = args.warning_msg_title or 'Huston, we have a problem'
     local warning_msg_text = args.warning_msg_text or 'Battery is dying'
@@ -116,7 +117,7 @@ local function worker(args)
     local last_battery_check = os.time()
     local batteryType = "battery-good-symbolic"
 
-    watch("acpi -i", 10,
+    watch("acpi -i", timeout,
     function(widget, stdout, stderr, exitreason, exitcode)
         local battery_info = {}
         local capacities = {}

--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -25,6 +25,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `arc_thickness` | 2 | Thickness of the arc |
 | `show_current_level`| false | Show current charge level |
 | `size`| 18 | Size of the widget |
+| `timeout` | 10 | How often in seconds the widget refreshes |
 | `main_color` | `beautiful.fg_color` | Color of the text with the current charge level and the arc |
 | `bg_color` | `#ffffff11` | Color of the charge level background |
 | `low_level_color` | `#e53935` | Arc color when battery charge is less that 15% |

--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -26,6 +26,7 @@ local function worker(args)
     local arc_thickness = args.arc_thickness or 2
     local show_current_level = args.show_current_level or false
     local size = args.size or 18
+    local timeout = args.timeout or 10
 
     local main_color = args.main_color or beautiful.fg_color
     local bg_color = args.bg_color or '#ffffff11'
@@ -114,7 +115,7 @@ local function worker(args)
         end
     end
 
-    watch("acpi", 10, update_widget, widget)
+    watch("acpi", timeout, update_widget, widget)
 
     -- Popup with battery info
     local notification

--- a/bitbucket-widget/README.md
+++ b/bitbucket-widget/README.md
@@ -19,6 +19,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `uuid` | Required | UUID |
 | `workspace` | Required | Workspace ID|
 | `repo_slug` | Required | Repository slug |
+| `timeout` | 60 | How often in seconds the widget refreshes |
 
 ## Installation
 

--- a/bitbucket-widget/bitbucket.lua
+++ b/bitbucket-widget/bitbucket.lua
@@ -76,6 +76,7 @@ local function worker(args)
     local uuid = args.uuid or show_warning('UUID is not set')
     local workspace = args.workspace or show_warning('Workspace is not set')
     local repo_slug = args.repo_slug or show_warning('Repo slug is not set')
+    local timeout = args.timeout or 60
 
     local current_number_of_prs
 
@@ -267,7 +268,7 @@ local function worker(args)
     )
 
     watch(string.format(GET_PRS_CMD, host, workspace, repo_slug, uuid, uuid),
-            60, update_widget, bitbucket_widget)
+            timeout, update_widget, bitbucket_widget)
     return bitbucket_widget
 end
 

--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -13,6 +13,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `dec_brightness_cmd` | `light -U 5`| Decrease brightness |
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
 | `font` | `Play 9` | Font |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 
 ### Example:
 

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -28,6 +28,7 @@ local function worker(args)
     local dec_brightness_cmd = args.dec_brightness_cmd or DEC_BRIGHTNESS_CMD
     local path_to_icon = args.path_to_icon or PATH_TO_ICON
     local font = args.font or 'Play 9'
+    local timeout = args.timeout or 1
 
     local brightness_text = wibox.widget.textbox()
     brightness_text:set_font(font)
@@ -61,7 +62,7 @@ local function worker(args)
         end
     end)
 
-    watch(get_brightness_cmd, 1, update_widget, brightness_text)
+    watch(get_brightness_cmd, timeout, update_widget, brightness_text)
 
     return widget
 end

--- a/brightnessarc-widget/README.md
+++ b/brightnessarc-widget/README.md
@@ -14,6 +14,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `color` | `beautiful.fg_color` | Color of the arc |
 | `bg_color` | `#ffffff11` | Color of the arc's background |
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 
 ### Example:
 

--- a/brightnessarc-widget/brightnessarc.lua
+++ b/brightnessarc-widget/brightnessarc.lua
@@ -30,6 +30,7 @@ local function worker(args)
     local color = args.color or beautiful.fg_color
     local bg_color = args.bg_color or '#ffffff11'
     local path_to_icon = args.path_to_icon or PATH_TO_ICON
+    local timeout = args.timeout or 1
 
     local icon = {
         id = "icon",
@@ -66,7 +67,7 @@ local function worker(args)
         end
     end)
 
-    watch(get_brightness_cmd, 1, update_widget, widget)
+    watch(get_brightness_cmd, timeout, update_widget, widget)
 
     return widget
 end

--- a/cpu-widget/README.md
+++ b/cpu-widget/README.md
@@ -28,6 +28,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `color` | `beautiful.fg_normal` | Color of the graph |
 | `enable_kill_button` | `false` | Show button which kills the process |
 | `process_info_max_length` | `-1` | Truncate the process information. Some processes may have a very long list of parameters which won't fit in the screen, this options allows to truncate it to the given length. |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 
 ### Example
 

--- a/cpu-widget/cpu-widget.lua
+++ b/cpu-widget/cpu-widget.lua
@@ -96,6 +96,7 @@ local function worker(args)
     local color = args.color or beautiful.fg_normal
     local enable_kill_button = args.enable_kill_button or false
     local process_info_max_length = args.process_info_max_length or -1
+    local timeout = args.timeout or 1
 
     local cpugraph_widget = wibox.widget {
         max_value = 100,
@@ -138,7 +139,7 @@ local function worker(args)
     local cpu_widget = wibox.container.margin(wibox.container.mirror(cpugraph_widget, { horizontal = true }), 0, 0, 0, 2)
 
     local cpus = {}
-    watch([[bash -c "cat /proc/stat | grep '^cpu.' ; ps -eo '%p|%c|%C|' -o "%mem" -o '|%a' --sort=-%cpu | head -11 | tail -n +2"]], 1,
+    watch([[bash -c "cat /proc/stat | grep '^cpu.' ; ps -eo '%p|%c|%C|' -o "%mem" -o '|%a' --sort=-%cpu | head -11 | tail -n +2"]], timeout,
             function(widget, stdout)
                 local i = 1
                 local j = 1

--- a/experiments/spotify-player/spotify-player.lua
+++ b/experiments/spotify-player/spotify-player.lua
@@ -34,6 +34,8 @@ local function worker(args)
 
     local args = args or {}
 
+    local timeout = args.timeout or 1
+
     local function get_artwork(track_id, url)
         if ((url ~= nil or url ~='') and not gfs.file_readable('/tmp/' .. track_id)) then
             spawn.easy_async('touch /tmp/' .. track_id, function()
@@ -191,7 +193,7 @@ local function worker(args)
             )
     )
 
-    watch('sp metadata', 1, update_widget, spotify_player)
+    watch('sp metadata', timeout, update_widget, spotify_player)
 
     return spotify_player
 end

--- a/fs-widget/fs-widget.lua
+++ b/fs-widget/fs-widget.lua
@@ -9,6 +9,7 @@ local storage_bar_widget = {}
 local function worker(args)
     local args = args or {}
     local mounts = args.mounts or {'/'}
+    local timeout = args.timeout or 60
 
     storage_bar_widget = wibox.widget {
         max_value = 100,
@@ -78,7 +79,7 @@ local function worker(args)
     local disk_widget = wibox.container.margin(storage_bar_widget, 0, 0, 0, 0)
 
     local disks = {}
-    watch([[bash -c "df | tail -n +2"]], 60,
+    watch([[bash -c "df | tail -n +2"]], timeout,
         function(widget, stdout)
           for line in stdout:gmatch("[^\r\n$]+") do
             local filesystem, size, used, avail, perc, mount =

--- a/gerrit-widget/README.md
+++ b/gerrit-widget/README.md
@@ -23,6 +23,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `icon`| `/.config/awesome/awesome-wm-widgets/gerrit-widget/gerrit_icon.svg`| Path to the icon |
 | `host` | Required | Ex https://gerrit.tmnt.com |
 | `query` | `is:reviewer AND status:open AND NOT is:wip` | Query to retrieve reviews |
+| `timeout` | 10 | How often in seconds the widget refreshes |
 
 ## Prerequisite
 

--- a/gerrit-widget/gerrit.lua
+++ b/gerrit-widget/gerrit.lua
@@ -38,6 +38,7 @@ local function worker(args)
         text = 'Gerrit host is unknown'
     }
     local query = args.query or 'is:reviewer AND status:open AND NOT is:wip'
+    local timeout = args.timeout or 10
 
     local current_number_of_reviews
     local previous_number_of_reviews = 0
@@ -220,7 +221,7 @@ local function worker(args)
         )
     )
 
-    watch(string.format(GET_CHANGES_CMD, host, query:gsub(" ", "+")), 10, update_widget, gerrit_widget)
+    watch(string.format(GET_CHANGES_CMD, host, query:gsub(" ", "+")), timeout, update_widget, gerrit_widget)
     return gerrit_widget
 end
 

--- a/jira-widget/README.md
+++ b/jira-widget/README.md
@@ -19,6 +19,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `host` | Required | Ex: _http://jira.tmnt.com_ |
 | `query` | `jql=assignee=currentuser() AND resolution=Unresolved` | JQL query |
 | `icon` | `~/.config/awesome/awesome-wm-widgets/jira-widget/jira-mark-gradient-blue.svg` | Path to the icon |
+| `timeout` | 10 | How often in seconds the widget refreshes |
 
 ## Installation
 

--- a/jira-widget/jira.lua
+++ b/jira-widget/jira.lua
@@ -107,6 +107,7 @@ local function worker(args)
     local icon = args.icon or HOME_DIR .. '/.config/awesome/awesome-wm-widgets/jira-widget/jira-mark-gradient-blue.svg'
     local host = args.host or show_warning('Jira host is unknown')
     local query = args.query or 'jql=assignee=currentuser() AND resolution=Unresolved'
+    local timeout = args.timeout or 10
 
     jira_widget:set_icon(icon)
 
@@ -229,7 +230,7 @@ local function worker(args)
             )
     )
     watch(string.format(GET_ISSUES_CMD, host, query:gsub(' ', '+')),
-            10, update_widget, jira_widget)
+            timeout, update_widget, jira_widget)
     return jira_widget
 end
 

--- a/net-speed-widget/net-speed.lua
+++ b/net-speed-widget/net-speed.lua
@@ -96,6 +96,7 @@ local function worker(args)
     local args = args or {}
 
     local interface = args.interface or '*'
+    local timeout = args.timeout or 1
 
     local update_widget = function(widget, stdout, stderr)
 
@@ -119,7 +120,7 @@ local function worker(args)
         prev_tx = cur_tx
     end
 
-    watch(string.format([[bash -c "cat /sys/class/net/%s/statistics/*_bytes"]], interface), 1, update_widget, net_speed_widget)
+    watch(string.format([[bash -c "cat /sys/class/net/%s/statistics/*_bytes"]], interface), timeout, update_widget, net_speed_widget)
 
     return net_speed_widget
 

--- a/ram-widget/ram-widget.lua
+++ b/ram-widget/ram-widget.lua
@@ -7,6 +7,7 @@ local ramgraph_widget = {}
 local function worker(args)
 
     local args = args or {}
+    local timeout = args.timeout or 1
 
     --- Main ram widget shown on wibar
     ramgraph_widget = wibox.widget {
@@ -48,7 +49,7 @@ local function worker(args)
         return math.floor(value / (total+total_swap) * 100 + 0.5) .. '%'
     end
 
-    watch('bash -c "LANGUAGE=en_US.UTF-8 free | grep -z Mem.*Swap.*"', 1,
+    watch('bash -c "LANGUAGE=en_US.UTF-8 free | grep -z Mem.*Swap.*"', timeout,
         function(widget, stdout, stderr, exitreason, exitcode)
             total, used, free, shared, buff_cache, available, total_swap, used_swap, free_swap =
                 stdout:match('(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*(%d+)%s*Swap:%s*(%d+)%s*(%d+)%s*(%d+)')

--- a/spotify-widget/README.md
+++ b/spotify-widget/README.md
@@ -33,6 +33,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `dim_opacity` | `0.2` | Widget's opacity when dimmed, `dim_when_paused` should be set to `true` |
 | `max_length` | `15` | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
 | `show_tooltip` | `true`| Show tooltip on hover with information about the playing song |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 
 
 ### Example:

--- a/spotify-widget/spotify.lua
+++ b/spotify-widget/spotify.lua
@@ -35,6 +35,7 @@ local function worker(args)
     local dim_opacity = args.dim_opacity or 0.2
     local max_length = args.max_length or 15
     local show_tooltip = args.show_tooltip == nil and false or args.show_tooltip
+    local timeout = args.timeout or 1
 
     local cur_artist = ''
     local cur_title = ''
@@ -106,8 +107,8 @@ local function worker(args)
         end
     end
 
-    watch(GET_SPOTIFY_STATUS_CMD, 1, update_widget_icon, spotify_widget)
-    watch(GET_CURRENT_SONG_CMD, 1, update_widget_text, spotify_widget)
+    watch(GET_SPOTIFY_STATUS_CMD, timeout, update_widget_icon, spotify_widget)
+    watch(GET_CURRENT_SONG_CMD, timeout, update_widget_text, spotify_widget)
 
     --- Adds mouse controls to the widget:
     --  - left click - play/pause

--- a/stackoverflow-widget/README.md
+++ b/stackoverflow-widget/README.md
@@ -13,6 +13,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `icon`| `/.config/awesome/awesome-wm-widgets/stackoverflow-widget/so-icon.svg` | Path to the icon |
 | `limit` | 5 | Number of items to show in the widget |
 | `tagged` | awesome-wm | Tag, or comma-separated tags |
+| `timeout` | 300 | How often in seconds the widget refreshes |
 
 ## Installation
 

--- a/stackoverflow-widget/stackoverflow.lua
+++ b/stackoverflow-widget/stackoverflow.lua
@@ -29,6 +29,7 @@ local function worker(args)
     local icon = args.icon or HOME_DIR .. '/.config/awesome/awesome-wm-widgets/stackoverflow-widget/so-icon.svg'
     local limit = args.limit or 5
     local tagged = args.tagged or 'awesome-wm'
+    local timeout = args.timeout or 300
 
     local rows = {
         { widget = wibox.widget.textbox },
@@ -115,7 +116,7 @@ local function worker(args)
                     end)
             )
     )
-    watch(string.format(GET_QUESTIONS_CMD, limit, tagged),  300, update_widget, stackoverflow_widget)
+    watch(string.format(GET_QUESTIONS_CMD, limit, tagged),  timeout, update_widget, stackoverflow_widget)
     return stackoverflow_widget
 end
 

--- a/volumearc-widget/README.md
+++ b/volumearc-widget/README.md
@@ -21,6 +21,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `path_to_icon` | /usr/share/icons/Arc/status/symbolic/audio-volume-muted-symbolic.svg | Path to the icon |
 | `thickness` | 2 | The arc thickness |
 | `height` | `beautiful.fg_normal` | Widget height |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 | `get_volume_cmd` | `amixer -D pulse sget Master` | Get current volume level |
 | `inc_volume_cmd` | `amixer -D pulse sset Master 5%+` | Increase volume level |
 | `dec_volume_cmd` | `amixer -D pulse sset Master 5%-` | Decrease volume level |

--- a/volumearc-widget/volumearc.lua
+++ b/volumearc-widget/volumearc.lua
@@ -33,6 +33,7 @@ local function worker(args)
     local path_to_icon = args.path_to_icon or PATH_TO_ICON
     local thickness = args.thickness or 2
     local height = args.height or 18
+    local timeout = args.timeout or 1
 
     local get_volume_cmd = args.get_volume_cmd or GET_VOLUME_CMD
     local inc_volume_cmd = args.inc_volume_cmd or INC_VOLUME_CMD
@@ -81,7 +82,7 @@ local function worker(args)
     end
     volumearc:connect_signal("button::press", button_press)
 
-    watch(get_volume_cmd, 1, update_graphic, volumearc)
+    watch(get_volume_cmd, timeout, update_graphic, volumearc)
 
     return volumearc
 end

--- a/volumebar-widget/README.md
+++ b/volumebar-widget/README.md
@@ -20,7 +20,8 @@ It is possible to customize widget by providing a table with all or some of the 
 | `mute_color` | `beautiful.fg_urgent` | Color of the bar when mute |
 | `width` | 50 | The bar width |
 | `shape` | `bar` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |
-| `margin` | `10` | Top and bottom margin (if your wibar is 22 px high, bar will be 2 px (22 - 2*10)) |
+| `margins` | `10` | Top and bottom margin (if your wibar is 22 px high, bar will be 2 px (22 - 2*10)) |
+| `timeout` | 1 | How often in seconds the widget refreshes |
 | `get_volume_cmd` | `amixer -D pulse sget Master` | Get current volume level |
 | `inc_volume_cmd` | `amixer -D pulse sset Master 5%+` | Increase volume level |
 | `dec_volume_cmd` | `amixer -D pulse sset Master 5%-` | Decrease volume level |

--- a/volumebar-widget/volumebar.lua
+++ b/volumebar-widget/volumebar.lua
@@ -32,6 +32,7 @@ local function worker(args)
     local width = args.width or 50
     local shape = args.shape or 'bar'
     local margins = args.margins or 10
+    local timeout = args.timeout or 1
 
     local get_volume_cmd = args.get_volume_cmd or GET_VOLUME_CMD
     local inc_volume_cmd = args.inc_volume_cmd or INC_VOLUME_CMD
@@ -77,7 +78,7 @@ local function worker(args)
         end)
     end)
 
-    watch(get_volume_cmd, 1, update_graphic, volumebar_widget)
+    watch(get_volume_cmd, timeout, update_graphic, volumebar_widget)
 
     return volumebar_widget
 end

--- a/weather-widget/README.md
+++ b/weather-widget/README.md
@@ -30,6 +30,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | show_daily_forecast | false | Show daily forecast section |
 | icon_pack_name | weather-underground-icons | Name of the icon pack, could be `weather-underground-icon` or `VitalyGorbachev` or create your own, more details below |
 | icons_extension | `.svg` | File extension of icons in the pack |
+| timeout | 120 | How often in seconds the widget refreshes |
 
 
 ### Icons:

--- a/weather-widget/weather.lua
+++ b/weather-widget/weather.lua
@@ -137,6 +137,7 @@ local function worker(args)
     local show_daily_forecast = args.show_daily_forecast
     local icon_pack_name = args.icons or 'weather-underground-icons'
     local icons_extension = args.icons_extension or '.png'
+    local timeout = args.timeout or 120
 
     local owm_one_cal_api =
         ('https://api.openweathermap.org/data/2.5/onecall' .. 
@@ -457,7 +458,7 @@ local function worker(args)
 
     watch(
         string.format(GET_FORECAST_CMD, owm_one_cal_api),
-        120,  -- API limit is 1k req/day; day has 1440 min; every 2 min is good
+        timeout,  -- API limit is 1k req/day; day has 1440 min; every 2 min is good
         update_widget, weather_widget
     )
 


### PR DESCRIPTION
Related to #187, this PR adds a `timeout` arg to most of the widgets. I picket the name `timeout` to match that of the [`awful.widget.watch:new` function's](https://awesomewm.org/doc/api/classes/awful.widget.watch.html#awful.widget.watch:new) `timeout` parameter.

I didn't update the `mpdarc`, `pomodoroarc`, or `rhythmbox` widgets because they appear to be written to not take in parameters. I also skipped updating the README files for a few widgets that currently don't document their parameters.