### PR TITLE
Updated logout.lua to stop the keygrabber when mouse is clicked on an option

### DIFF
--- a/logout-widget/logout.lua
+++ b/logout-widget/logout.lua
@@ -49,6 +49,7 @@ local function create_button(icon_name, action_name, color, onclick)
         onclick = function()
             onclick()
             w.visible = false
+            capi.keygrabber.stop()
         end
     }
     button:connect_signal("mouse::enter", function(c) action:set_text(action_name) end)


### PR DESCRIPTION
Not stopping keygrabber makes it impossible to use locking solutions like i3lock that tries to grab keyboard.
i3lock-fancy fails with error `i3lock: Cannot grab pointer/keyboard` without this patch