### PR TITLE
show notification on right click for volume/battery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ luac.out
 
 # IDEA files
 .idea
+
+# vscode files
+.history

--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -32,6 +32,7 @@ local function worker(args)
     local margin_right = args.margin_right or 0
 
     local display_notification = args.display_notification or false
+    local display_notification_onClick = args.display_notification_onClick or true
     local position = args.notification_position or "top_right"
     local timeout = args.timeout or 10
 
@@ -182,7 +183,13 @@ local function worker(args)
     if display_notification then
         battery_widget:connect_signal("mouse::enter", function() show_battery_status(batteryType) end)
         battery_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
+    elseif display_notification_onClick then
+        battery_widget:connect_signal("button::press", function(_,_,_,button) 
+            if (button == 3) then show_battery_status(batteryType) end
+        end)
+        battery_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
     end
+    
     return wibox.container.margin(battery_widget, margin_left, margin_right)
 end
 


### PR DESCRIPTION
Personally I find it sometimes handy to see the notification the volume widget and the battery widget provide. But only rarely, I am definitely not a fan of activating display_notification. 

This PR addresses this by adding a display_notification_onClick option which when set, allows to trigger the notification on a right click (button == 3).