### PR TITLE
Added 'Not charging' to possible battery states.

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -123,7 +123,7 @@ local function worker(args)
         local battery_info = {}
         local capacities = {}
         for s in stdout:gmatch("[^\r\n]+") do
-            local status, charge_str, time = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?(.*)')
+            local status, charge_str, time = string.match(s, '.+: ([%a ]+), (%d?%d?%d)%%,?(.*)')
             if status ~= nil then
                 table.insert(battery_info, {status = status, charge = tonumber(charge_str)})
             else
@@ -184,12 +184,12 @@ local function worker(args)
         battery_widget:connect_signal("mouse::enter", function() show_battery_status(batteryType) end)
         battery_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
     elseif display_notification_onClick then
-        battery_widget:connect_signal("button::press", function(_,_,_,button) 
+        battery_widget:connect_signal("button::press", function(_,_,_,button)
             if (button == 3) then show_battery_status(batteryType) end
         end)
         battery_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
     end
-    
+
     return wibox.container.margin(battery_widget, margin_left, margin_right)
 end
 

--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -71,8 +71,8 @@ local function worker(args)
         local charge = 0
         local status
         for s in stdout:gmatch("[^\r\n]+") do
-            local cur_status, charge_str, time = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?(.*)')
-            if cur_status ~= nil and charge_str ~=nil then
+            local cur_status, charge_str, time = string.match(s, '.+: ([%a ]+), (%d?%d?%d)%%,?(.*)')
+            if cur_status ~= nil and charge_str ~= nil then
                 local cur_charge = tonumber(charge_str)
                 if cur_charge > charge then
                     status = cur_status


### PR DESCRIPTION
The `battery` and `batteryarc` modules broke for me when the battery status returned by `acpi` was `Not charging`. This PR fixes this by simply adding spaces as possible status characters.

Please note that the `Not charging` status is treated the same way as the `Discharging` status.