### PR TITLE
Fixed minor issues in logout-popup widget

### DIFF
--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -28,11 +28,11 @@ Then
 - to show by a shortcut - define a shortcut in `globalkeys`:
 
     ```lua
-    local logout = require("awesome-wm-widgets.experiments.logout-widget.logout")
+    local logout_popup = require("awesome-wm-widgets.logout-popup-widget.logout-popup")
     ...
     globalkeys = gears.table.join(
     ...
-        awful.key({ modkey }, "l", function() logout.launch() end, {description = "Show logout screen", group = "custom"}),
+        awful.key({ modkey }, "l", function() logout_popup.launch() end, {description = "Show logout screen", group = "custom"}),
     ```
 
 - to show by clicking on a widget in wibar - add widget to the wibar:

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -59,7 +59,8 @@ local function create_button(icon_name, action_name, color, onclick, icon_size, 
     return button
 end
 
-local function launch(args)
+local function launch(user_args)
+    local args = user_args or {}
 
     local bg_color = args.bg_color or beautiful.bg_normal
     local accent_color = args.accent_color or beautiful.bg_focus

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -59,8 +59,8 @@ local function create_button(icon_name, action_name, color, onclick, icon_size, 
     return button
 end
 
-local function launch(user_args)
-    local args = user_args or {}
+local function launch(args)
+    args = args or {}
 
     local bg_color = args.bg_color or beautiful.bg_normal
     local accent_color = args.accent_color or beautiful.bg_focus


### PR DESCRIPTION
- The README for the logout-popup-widget had an outdated path for the logout-popup in the globalkeys section. Updated it to refer to the current location.
- Fixed issue in the launch() function in logout-popup.lua that was causing a nil error when not passed an args object. 