### PR TITLE
Brightness: add support for left/right click

### DIFF
--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -15,6 +15,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
 | `font` | `Play 9` | Font |
 | `timeout` | 1 | How often in seconds the widget refreshes. Check the note below |
+| `tooltip` | false | Display brightness level in a tooltip when the mouse cursor hovers the widget |
 
 _Note:_ If brightness is controlled only by the widget (either by a mouse, or by a shortcut, then the `timeout` could be quite big, as there is no reason to synchronize the brightness level).
 

--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -11,6 +11,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `type`| `arc` | The widget type. Could be `arc` or `icon_and_text` |
 | `program` | `light` | The program used to control the brightness, either 'light' or 'xbacklight'. |
 | `step` | 5 | Step |
+| `base` | 20 | Base level to set brightness to on left click. |
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
 | `font` | `Play 9` | Font |
 | `timeout` | 1 | How often in seconds the widget refreshes. Check the note below |

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -41,7 +41,7 @@ local function worker(user_args)
     local program = args.program or 'light'
     local step = args.step or 5
     local base = args.base or 20
-    local level = 0 -- current brightness value
+    local current_level = 0 -- current brightness value
     local tooltip = args.tooltip or false
     if program == 'light' then
         get_brightness_cmd = 'light -G'
@@ -110,12 +110,12 @@ local function worker(user_args)
 
     local update_widget = function(widget, stdout, _, _, _)
         local brightness_level = tonumber(string.format("%.0f", stdout))
-        level = brightness_level
+        current_level = brightness_level
         widget:set_value(brightness_level)
     end
 
     function brightness_widget:set(value)
-        level = value
+        current_level = value
         spawn.easy_async(set_brightness_cmd .. value, function()
             spawn.easy_async(get_brightness_cmd, function(out)
                 update_widget(brightness_widget.widget, out)
@@ -128,15 +128,15 @@ local function worker(user_args)
             -- avoid toggling between '0' and 'almost 0'
             old_level = 1
         end
-        if level < 0.1 then
+        if current_level < 0.1 then
             -- restore previous level
-            level = old_level
+            current_level = old_level
         else
             -- save current brightness for later
-            old_level = level
-            level = 0
+            old_level = current_level
+            current_level = 0
         end
-        brightness_widget:set(level)
+        brightness_widget:set(current_level)
     end
     function brightness_widget:inc()
         spawn.easy_async(inc_brightness_cmd, function()
@@ -168,7 +168,7 @@ local function worker(user_args)
         awful.tooltip {
             objects        = { brightness_widget.widget },
             timer_function = function()
-                return level .. " %"
+                return current_level .. " %"
             end,
         }
     end

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -42,6 +42,7 @@ local function worker(user_args)
     local step = args.step or 5
     local base = args.base or 20
     local level = 0 -- current brightness value
+    local tooltip = args.tooltip or false
     if program == 'light' then
         get_brightness_cmd = 'light -G'
         set_brightness_cmd = 'light -S ' -- <level>
@@ -162,6 +163,15 @@ local function worker(user_args)
     )
 
     watch(get_brightness_cmd, timeout, update_widget, brightness_widget.widget)
+
+    if tooltip then
+        awful.tooltip {
+            objects        = { brightness_widget.widget },
+            timer_function = function()
+                return level .. " %"
+            end,
+        }
+    end
 
     return brightness_widget.widget
 end

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -40,9 +40,9 @@ local function worker(user_args)
     local program = args.program or 'light'
     local step = args.step or 5
     if program == 'light' then
-        get_brightness_cmd = 'sh -c "light -G"'
-        inc_brightness_cmd = 'sh -c "light -A ' .. step .. '"'
-        dec_brightness_cmd = 'sh -c "light -U ' .. step .. '"'
+        get_brightness_cmd = 'light -G'
+        inc_brightness_cmd = 'light -A ' .. step
+        dec_brightness_cmd = 'light -U ' .. step
     elseif program == 'xbacklight' then
         get_brightness_cmd = 'xbacklight -get'
         inc_brightness_cmd = 'xbacklight -inc ' .. step


### PR DESCRIPTION
add the following features to the brightness-widget:
- left click sets brightness to "base" level
- right click toggles brightness between current level and 0
- tooltip showing current level (disabled by default to keep current behaviour)
- minor refactoring to support these features

Feedback is welcome :)