### PR TITLE
Fix email widgets being inaccessible

### DIFF
--- a/email-widget/README.md
+++ b/email-widget/README.md
@@ -14,7 +14,8 @@ To install it put **email.lua** and **email-widget** folder under **~/.config/aw
  - add widget to awesome:
 
 ```lua
-require("email")
+local email_widget, email_icon = require("email")
+
 ...
 s.mytasklist, -- Middle widget
 	{ -- Right widgets

--- a/email-widget/email.lua
+++ b/email-widget/email.lua
@@ -40,3 +40,5 @@ local function show_emails()
 end
 
 email_icon:connect_signal("mouse::enter", function() show_emails() end)
+
+return email_widget, email_icon


### PR DESCRIPTION
This came up on IRC. Apparently a recent effort to fix linter warnings broke these as the then global values became local and inaccessible.