### PR TITLE
Add an alternative to change the color of the button's label

### DIFF
--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -58,6 +58,7 @@ Then
 | `bg_color` |  `beautiful.bg_normal` | The color the background of the |
 | `accent_color` | `beautiful.bg_focus` | The color of the buttons |
 | `text_color` | `beautiful.fg_normal` | The color of text |
+| `label_color` | `beautiful.fg_normal` | The color of the button's label |
 | `phrases` | `{'Goodbye!'}` | The table with phrase(s) to show, if more than one provided, the phrase is chosen randomly. Leave empty (`{}`) to hide the phrase |
 | `onlogout` | `function() awesome.quit() end` | Function which is called when the logout button is pressed |
 | `onlock` | `function() awful.spawn.with_shell("systemctl suspend") end` | Function which is called when the lock button is pressed |

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -40,12 +40,12 @@ local phrase_widget = wibox.widget{
     widget = wibox.widget.textbox
 }
 
-local function create_button(icon_name, action_name, color, onclick, icon_size, icon_margin)
+local function create_button(icon_name, action_name, accent_color, label_color, onclick, icon_size, icon_margin)
 
     local button = awesomebuttons.with_icon {
         type = 'basic',
         icon = icon_name,
-        color = color,
+        color = accent_color,
         icon_size = icon_size,
         icon_margin = icon_margin,
         onclick = function()
@@ -54,8 +54,11 @@ local function create_button(icon_name, action_name, color, onclick, icon_size, 
             capi.keygrabber.stop()
         end
     }
-    button:connect_signal("mouse::enter", function() action:set_text(action_name) end)
-    button:connect_signal("mouse::leave", function() action:set_text(' ') end)
+    button:connect_signal("mouse::enter", 
+      function() action:set_markup('<span color="' .. label_color .. '">' .. action_name .. '</span>') end)
+    
+    button:connect_signal("mouse::leave", function() action:set_markup('<span> </span>') end)
+
     return button
 end
 
@@ -65,6 +68,7 @@ local function launch(args)
     local bg_color = args.bg_color or beautiful.bg_normal
     local accent_color = args.accent_color or beautiful.bg_focus
     local text_color = args.text_color or beautiful.fg_normal
+    local label_color = args.label_color or beautiful.fg_focus
     local phrases = args.phrases or {'Goodbye!'}
     local icon_size = args.icon_size or 40
     local icon_margin = args.icon_margin or 16
@@ -86,11 +90,11 @@ local function launch(args)
             phrase_widget,
             {
                 {
-                    create_button('log-out', 'Log Out (l)', accent_color, onlogout, icon_size, icon_margin),
-                    create_button('lock', 'Lock (k)', accent_color, onlock, icon_size, icon_margin),
-                    create_button('refresh-cw', 'Reboot (r)', accent_color, onreboot, icon_size, icon_margin),
-                    create_button('moon', 'Suspend (u)', accent_color, onsuspend, icon_size, icon_margin),
-                    create_button('power', 'Power Off (s)', accent_color, onpoweroff, icon_size, icon_margin),
+                    create_button('log-out', 'Log Out (l)', accent_color, label_color, onlogout, icon_size, icon_margin),
+                    create_button('lock', 'Lock (k)', accent_color, label_color, onlock, icon_size, icon_margin),
+                    create_button('refresh-cw', 'Reboot (r)', accent_color, label_color, onreboot, icon_size, icon_margin),
+                    create_button('moon', 'Suspend (u)', accent_color, label_color, onsuspend, icon_size, icon_margin),
+                    create_button('power', 'Power Off (s)', accent_color, label_color, onpoweroff, icon_size, icon_margin),
                     id = 'buttons',
                     spacing = 8,
                     layout = wibox.layout.fixed.horizontal


### PR DESCRIPTION
The color of the button's label is hard to read in light themes as shown bellow. To fix this issue, I added the property `label_color` to allow the user to set the label's color the same way as how we currently set background and text colors, that is by adding `label_color = "#color_code"` in the widget or in the popup's properties. 

Using the example from the widget's README, this is how we could set the button's label to white:

```
logout.launch{
    bg_color = "#261447", accent_color = "#ff4365", text_color = '#f706cf', label_color = "#ffffff", 
    icon_size = 40, icon_margin = 16,
    -- bg_color = "#0b0c10", accent_color = "#1f2833", text_color = '#66fce1', -- dark
    -- bg_color = "#3B4252", accent_color = "#88C0D0", text_color = '#D8DEE9', -- nord
    -- bg_color = "#282a36", accent_color = "#ff79c6", phrases = {}, -- dracula, no phrase
    phrases = {"exit(0)", "Don't forget to be awesome.", "Yippee ki yay!"},
}
```

Before commit:
![before](https://user-images.githubusercontent.com/48293220/119181317-ca098d00-ba47-11eb-8836-1e3b3d474878.jpg)

After commit:
![after](https://user-images.githubusercontent.com/48293220/119181344-d988d600-ba47-11eb-9710-83112af3c8d6.jpg)

