### PR TITLE
net-speed bugfix

### DIFF
--- a/net-speed-widget/net-speed.lua
+++ b/net-speed-widget/net-speed.lua
@@ -17,9 +17,6 @@ local ICONS_DIR = WIDGET_DIR .. 'icons/'
 
 local net_speed_widget = {}
 
-local prev_rx = 0
-local prev_tx = 0
-
 local function convert_to_h(bytes)
     local speed
     local dim
@@ -92,6 +89,11 @@ local function worker(user_args)
         end
     }
 
+    -- make sure these are not shared across different worker/widgets (e.g. two monitors)
+    -- otherwise the speed will be randomly split among the worker in each monitor
+    local prev_rx = 0
+    local prev_tx = 0
+
     local update_widget = function(widget, stdout)
 
         local cur_vals = split(stdout, '\r\n')
@@ -99,9 +101,9 @@ local function worker(user_args)
         local cur_rx = 0
         local cur_tx = 0
 
-        for i, _ in ipairs(cur_vals) do
-            if i%2 == 1 then cur_rx = cur_rx + cur_vals[i] end
-            if i%2 == 0 then cur_tx = cur_tx + cur_vals[i] end
+        for i, v in ipairs(cur_vals) do
+            if i%2 == 1 then cur_rx = cur_rx + v end
+            if i%2 == 0 then cur_tx = cur_tx + v end
         end
 
         local speed_rx = (cur_rx - prev_rx) / timeout

--- a/net-speed-widget/net-speed.lua
+++ b/net-speed-widget/net-speed.lua
@@ -104,8 +104,8 @@ local function worker(user_args)
             if i%2 == 0 then cur_tx = cur_tx + cur_vals[i] end
         end
 
-        local speed_rx = cur_rx - prev_rx
-        local speed_tx = cur_tx - prev_tx
+        local speed_rx = (cur_rx - prev_rx) / timeout
+        local speed_tx = (cur_tx - prev_tx) / timeout
 
         widget:set_rx_text(convert_to_h(speed_rx))
         widget:set_tx_text(convert_to_h(speed_tx))


### PR DESCRIPTION
This PR fixes two bugs:

1. speed was wrong when using a timeout other than one: the number of bytes needs to be divided by the timeout to get speed (`speed=bytes/time`);

2. the scope of the `prev_rx` and `prev_tx` variables was shared across all instances of the `update_widget` function:
https://github.com/streetturtle/awesome-wm-widgets/blob/7ecaccf85fd1ec7f3dc4754c124f80acfe7eec2c/net-speed-widget/net-speed.lua#L113-L114
  when more than one instance of the widget is created (e.g. when using multiple monitors), each widget would override each other's value; easy fix is to move these variables inside of the `worker` function so each worker gets it's own variable.

I've tested these changes using two monitors/widgets with timeout=2 and while generating traffic at known speeds using iperf3.