### PR TITLE
[fs-widget] Implement an alternative config pattern

### DIFF
--- a/fs-widget/fs-widget.lua
+++ b/fs-widget/fs-widget.lua
@@ -34,37 +34,27 @@ config.popup_bar_border_color = '#535d6c66'
 local function worker(user_args)
     local args = user_args or {}
 
-    if beautiful ~= nil then
-        config.widget_bar_color = beautiful.fg_normal
-        config.widget_border_color = beautiful.bg_focus
-        config.widget_onclick_bg = beautiful.bg_focus
-        config.widget_background_color = beautiful.bg_normal
-
-        config.popup_bg = beautiful.bg_normal
-        config.popup_border_color = beautiful.bg_focus
-        config.popup_bar_color = beautiful.fg_normal
-        config.popup_bar_border_color = beautiful.bg_focus
-        config.popup_bar_background_color = beautiful.bg_normal
-        config.popup_bar_border_color = beautiful.bg_focus
-    end
-
-    for prop, value in pairs(args) do
-        config[prop] = value
+    -- Setup config for the widget instance.
+    -- The `_config` table will keep the first existing value after checking
+    -- in this order: user parameter > beautiful > module default.
+    local _config = {}
+    for prop, value in pairs(config) do
+        _config[prop] = args[prop] or beautiful[prop] or value
     end
 
     storage_bar_widget = wibox.widget {
         {
             id = 'progressbar',
-            color = config.widget_bar_color,
+            color = _config.widget_bar_color,
             max_value = 100,
             forced_height = 20,
-            forced_width = config.widget_width,
+            forced_width = _config.widget_width,
             paddings = 2,
             margins = 4,
             border_width = 1,
             border_radius = 2,
-            border_color = config.widget_border_color,
-            background_color = config.widget_background_color,
+            border_color = _config.widget_border_color,
+            background_color = _config.widget_background_color,
             widget = wibox.widget.progressbar
         },
         shape = function(cr, width, height)
@@ -99,12 +89,12 @@ local function worker(user_args)
     disk_header:ajust_ratio(1, 0, 0.3, 0.7)
 
     local popup = awful.popup {
-        bg = config.popup_bg,
+        bg = _config.popup_bg,
         ontop = true,
         visible = false,
         shape = gears.shape.rounded_rect,
-        border_width = config.popup_border_width,
-        border_color = config.popup_border_color,
+        border_width = _config.popup_border_width,
+        border_color = _config.popup_border_color,
         maximum_width = 400,
         offset = { y = 5 },
         widget = {}
@@ -117,7 +107,7 @@ local function worker(user_args)
                             popup.visible = not popup.visible
                             storage_bar_widget:set_bg('#00000000')
                         else
-                            storage_bar_widget:set_bg(config.widget_background_color)
+                            storage_bar_widget:set_bg(_config.widget_background_color)
                             popup:move_next_to(mouse.current_widget_geometry)
                         end
                     end)
@@ -125,7 +115,7 @@ local function worker(user_args)
     )
 
     local disks = {}
-    watch([[bash -c "df | tail -n +2"]], config.refresh_rate,
+    watch([[bash -c "df | tail -n +2"]], _config.refresh_rate,
             function(widget, stdout)
                 for line in stdout:gmatch("[^\r\n$]+") do
                     local filesystem, size, used, avail, perc, mount =
@@ -139,12 +129,12 @@ local function worker(user_args)
                     disks[mount].perc = perc
                     disks[mount].mount = mount
 
-                    if disks[mount].mount == config.mounts[1] then
+                    if disks[mount].mount == _config.mounts[1] then
                         widget:set_value(tonumber(disks[mount].perc))
                     end
                 end
 
-                for k, v in ipairs(config.mounts) do
+                for k, v in ipairs(_config.mounts) do
 
                     local row = wibox.widget {
                         {
@@ -153,17 +143,17 @@ local function worker(user_args)
                             widget = wibox.widget.textbox
                         },
                         {
-                            color = config.popup_bar_color,
+                            color = _config.popup_bar_color,
                             max_value = 100,
                             value = tonumber(disks[v].perc),
                             forced_height = 20,
                             paddings = 1,
                             margins = 4,
                             border_width = 1,
-                            border_color = config.popup_bar_border_color,
-                            background_color = config.popup_bar_background_color,
+                            border_color = _config.popup_bar_border_color,
+                            background_color = _config.popup_bar_background_color,
                             bar_border_width = 1,
-                            bar_border_color = config.popup_bar_border_color,
+                            bar_border_color = _config.popup_bar_border_color,
                             widget = wibox.widget.progressbar,
                         },
                         {


### PR DESCRIPTION
Hello, 

(This PR targets your `274-make-beatiful-optional` branch)

I didn't have time to do this earlier, but at least, here it is: my take on making beautiful not a hard dependency for the fs-widget. (Also, please note this is untested)

My solution is actually quite easy:

You already have defined the (module level) global `config` table that holds all the available config properties and their default values. I trusted this table to set the local widget instance configuration table.
In the widget instance constructor, I add a `_config` table that holds the local version of the global config table. The local `_config` can be blindly used by the widget instance as "its own definition of configuration" ([1]).
I then replaced all the usage of the `config` table by the instance level `_config` table.

The main idea here is that the instance level `_config` table will be a copy of the global `config` table. With the exception, it's also checking for the first available value from `args`, `beautiful`, then fallback to the default.
(A notable limitation for this is that it will not work with nested table!)

Note: In the Awesome source code, we generally don't do a full copy of the default config table. Instead, we do the `args or beautiful or default` check every time we need to access the config value. We could have a debate on "what's the best approach: code readability/performance with a local config or save memory by doing the check". I personally think both approaches are equivalent at the end of the day...

[1]: Another approach with more complex widget would be to have something like `self._private.config` and some meta-table methods to properly implement getters and setters for these properties.

CC: @raven2cz 