### PR TITLE
[github-contributions] bad day_idx init.

### DIFF
--- a/github-contributions-widget/github-contributions-widget.lua
+++ b/github-contributions-widget/github-contributions-widget.lua
@@ -13,7 +13,7 @@ local naughty = require("naughty")
 local wibox = require("wibox")
 local widget_themes = require("awesome-wm-widgets.github-contributions-widget.themes")
 
-local GET_CONTRIBUTIONS_CMD = [[bash -c "curl -s https://github-contributions.now.sh/api/v1/%s]]
+local GET_CONTRIBUTIONS_CMD = [[bash -c "curl -s https://github-contributions.vercel.app/api/v1/%s]]
     .. [[ | jq -r '[.contributions[] ]]
     .. [[ | select ( .date | strptime(\"%%Y-%%m-%%d\") | mktime < now)][:%s]| .[].intensity'"]]
 
@@ -78,8 +78,8 @@ local function worker(user_args)
 
     local col = {layout = wibox.layout.fixed.vertical}
     local row = {layout = wibox.layout.fixed.horizontal}
-    local day_idx = 5 - os.date('%w')
-    for _ = 0, day_idx do
+    local day_idx = 6 - os.date('%w')
+    for _ = 1, day_idx do
         table.insert(col, get_square(color_of_empty_cells))
     end
 


### PR DESCRIPTION
`day_idx` is incremented AFTER insertion in the table `col` and `%7` test (in the `update_widget` function).
So it should be initialized with the number of empty cells we added.
So I propose to change its definition and the next for loop (empty cells) without changing the for loop inside `update_widget`.

Initial code add correct number of empty_cells but add also another square (another day) in the first col, thus first col had a square more than  other cols.