### PR TITLE
Bad day_idx

### DIFF
--- a/github-contributions-widget/github-contributions-widget.lua
+++ b/github-contributions-widget/github-contributions-widget.lua
@@ -38,6 +38,7 @@ local function worker(user_args)
     local args = user_args or {}
     local username = args.username or 'streetturtle'
     local days = args.days or 365
+    local square_size = args.square_size or 3
     local color_of_empty_cells = args.color_of_empty_cells
     local with_border = args.with_border
     local margin_top = args.margin_top or 1
@@ -57,11 +58,16 @@ local function worker(user_args)
 
         return wibox.widget{
             fit = function()
-                return 3, 3
+                return square_size, square_size
             end,
             draw = function(_, _, cr, _, _)
                 cr:set_source(gears.color(color))
-                cr:rectangle(0, 0, with_border and 2 or 3, with_border and 2 or 3)
+                cr:rectangle(
+                    0,
+                    0,
+                    with_border and square_size-1 or square_size,
+                    with_border and square_size-1 or square_size
+                )
                 cr:fill()
             end,
             layout = wibox.widget.base.make_widget

--- a/github-contributions-widget/github-contributions-widget.lua
+++ b/github-contributions-widget/github-contributions-widget.lua
@@ -76,8 +76,8 @@ local function worker(user_args)
 
     local col = {layout = wibox.layout.fixed.vertical}
     local row = {layout = wibox.layout.fixed.horizontal}
-    local day_idx = 5 - os.date('%w')
-    for _ = 0, day_idx do
+    local day_idx = 6 - os.date('%w')
+    for _ = 1, day_idx do
         table.insert(col, get_square(color_of_empty_cells))
     end
 


### PR DESCRIPTION
I previously commit this important change but I'm not really used to contribute using branches so it failed... and your current master version do not have these changes. Sorry.

I paste below the same comment I've already done:

```
day_idx is incremented AFTER insertion in the table col and %7 test (in the update_widget function).
So it should be initialized with the number of empty cells we added.
So I propose to change its definition and the next for loop (empty cells) without changing the for loop inside update_widget.

Initial code add correct number of empty_cells but add also another square (another day) in the first col, thus first col had a square more than other cols.
```