### PR TITLE
[weather-widget] enable locale

### DIFF
--- a/weather-widget/locale/en.lua
+++ b/weather-widget/locale/en.lua
@@ -1,0 +1,14 @@
+local en = {
+    warning_title = "Weather Widget",
+    parameter_warning = "Required parameters are not set: ",
+    directions = {
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW",
+        "WSW", "W", "WNW", "NW", "NNW", "N"
+    },
+    feels_like = "Feels like ",
+    wind = "Wind: ",
+    humidity = "Humidity: ",
+    uv = "UV: "
+}
+
+return en

--- a/weather-widget/locale/fr.lua
+++ b/weather-widget/locale/fr.lua
@@ -1,0 +1,14 @@
+local fr =  {
+    warning_title = "Widget Météo",
+    parameter_warning = "Les paramètres suivants sont obligatoires : ",
+    directions = {
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSO", "SO",
+        "OSO", "O", "ONO", "NO", "NNO", "N"
+    },
+    feels_like = "ressentie à ",
+    wind = "Vent : ",
+    humidity =  "Humidité : ",
+    uv = "Indice UV : "
+}
+
+return fr


### PR DESCRIPTION
I create `locale` directory  currently populated with two files `en.lua` and `fr.lua` with translated strings.
In `weather.lua`, interface strings are pointing to those files.

So I fetch first `LANG` env. variable and possibly return to `en`glish in case system language is missing.
I also add `lang` option in URL request so that `description` field fits the correct language.