### PR TITLE
Add a step parameter for volume_widget:inc() and :dec()

### DIFF
--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -43,8 +43,8 @@ Note that widget uses following command the get the current volume: `amixer -D p
 To improve responsiveness of the widget when volume level is changed by a shortcut use corresponding methods of the widget:
 
 ```lua
-awful.key({ modkey }, "]", function() volume_widget:inc() end),
-awful.key({ modkey }, "[", function() volume_widget:dec() end),
+awful.key({ modkey }, "]", function() volume_widget:inc(5) end),
+awful.key({ modkey }, "[", function() volume_widget:dec(5) end),
 awful.key({ modkey }, "\\", function() volume_widget:toggle() end),
 ```
 
@@ -57,6 +57,7 @@ It is possible to customize the widget by providing a table with all or some of 
 | Name | Default | Description |
 |---|---|---|
 | `mixer_cmd` | `pavucontrol` | command to run on middle click (e.g. a mixer program) |
+| `step` | `5` | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
 
 Depending on the chosen widget type add parameters from the corresponding section below:

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -18,8 +18,8 @@ local utils = require("awesome-wm-widgets.volume-widget.utils")
 
 local LIST_DEVICES_CMD = [[sh -c "pacmd list-sinks; pacmd list-sources"]]
 local GET_VOLUME_CMD = 'amixer -D pulse sget Master'
-local INC_VOLUME_CMD
-local DEC_VOLUME_CMD
+local function INC_VOLUME_CMD(step) return 'amixer -D pulse sset Master ' .. step .. '%+' end
+local function DEC_VOLUME_CMD(step) return 'amixer -D pulse sset Master ' .. step .. '%-' end
 local TOG_VOLUME_CMD = 'amixer -D pulse sset Master toggle'
 
 
@@ -168,9 +168,6 @@ local function worker(user_args)
     local refresh_rate = args.refresh_rate or 1
     local step = args.step or 5
 
-    INC_VOLUME_CMD = 'amixer -D pulse sset Master ' .. step .. '%+'
-    DEC_VOLUME_CMD = 'amixer -D pulse sset Master ' .. step .. '%-'
-
     if widget_types[widget_type] == nil then
         volume.widget = widget_types['icon_and_text'].get_widget(args.icon_and_text_args)
     else
@@ -187,12 +184,12 @@ local function worker(user_args)
         widget:set_volume_level(volume_level)
     end
 
-    function volume:inc()
-        spawn.easy_async(INC_VOLUME_CMD, function(stdout) update_graphic(volume.widget, stdout) end)
+    function volume:inc(s)
+        spawn.easy_async(INC_VOLUME_CMD(s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
-    function volume:dec()
-        spawn.easy_async(DEC_VOLUME_CMD, function(stdout) update_graphic(volume.widget, stdout) end)
+    function volume:dec(s)
+        spawn.easy_async(DEC_VOLUME_CMD(s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:toggle()


### PR DESCRIPTION
This is needed for using different step sizes for the inc and dec keybind (ie.: use 1 for inc and 3 for dec to gain precise volume control while keeping the ability to turn volume down fast).
The mousewheel still just uses the step for inc and dec.

(Sorry for the little accident with the 2 PRs, ignore the first.)