### PR TITLE
Fixes issue while printing song names containing certain unicode characters.

### DIFF
--- a/spotify-widget/spotify.lua
+++ b/spotify-widget/spotify.lua
@@ -16,8 +16,8 @@ local GET_SPOTIFY_STATUS_CMD = 'sp status'
 local GET_CURRENT_SONG_CMD = 'sp current'
 
 local function ellipsize(text, length)
-    return (text:len() > length and length > 0)
-        and text:sub(0, length - 3) .. '...'
+    return (utf8.len(text) > length and length > 0)
+        and text:sub(0, utf8.offset(text, length - 2) - 1) .. '...'
         or text
 end
 


### PR DESCRIPTION
The ellipsize function would earlier just truncate the string at the specified length. However, this causes issues if the song contains certain unicode characters in the name.
For example, considering [this](https://open.spotify.com/track/5h8jp1tzNDBhETtY4l1pjI?si=e4a1ac116b2b4694) japanese song, if the max_length is set to 14, the following error will happen due to the invalid truncation.

> Error on line 1 char 23: Invalid UTF-8 encoded text in name — not valid “バイ・�..”

![image](https://user-images.githubusercontent.com/62019276/136574453-ee6edde0-5cab-438d-889f-705a347ef675.png)

I've made it so that, the characters are truncated properly even in these cases.

![image](https://user-images.githubusercontent.com/62019276/136574984-d0eb3da0-7634-493c-9d57-c129dfe2c2a8.png)
