### PR TITLE
mpris-widget: another round of improvements

### DIFF
--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -72,9 +72,9 @@ local popup = awful.popup{
 
 local function rebuild_popup()
     awful.spawn.easy_async(LIST_PLAYERS_CMD, function(stdout, _, _, _)
+        for i = 0, #rows do rows[i]=nil end
         for player_name in stdout:gmatch("[^\r\n]+") do
             if player_name ~='' and player_name ~=nil then
-                for i = 0, #rows do rows[i]=nil end
 
                 local checkbox = wibox.widget{
                     {

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -73,7 +73,7 @@ local popup = awful.popup{
 local function rebuild_popup()
     awful.spawn.easy_async(LIST_PLAYERS_CMD, function(stdout, _, _, _)
         for player_name in stdout:gmatch("[^\r\n]+") do
-            if player_name ~='' or player_name ~=nil then
+            if player_name ~='' and player_name ~=nil then
                 for i = 0, #rows do rows[i]=nil end
 
                 local checkbox = wibox.widget{

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -16,8 +16,6 @@ local gears = require("gears")
 local GET_MPD_CMD = "playerctl -p %s -f '{{status}};{{xesam:artist}};{{xesam:title}};{{mpris:artUrl}}' metadata"
 
 local TOGGLE_MPD_CMD = "playerctl play-pause"
-local PAUSE_MPD_CMD = "playerctl pause"
-local STOP_MPD_CMD = "playerctl stop"
 local NEXT_MPD_CMD = "playerctl next"
 local PREV_MPD_CMD = "playerctl previous"
 local LIST_PLAYERS_CMD = "playerctl -l"
@@ -200,25 +198,6 @@ local function worker()
             widget.colors = {beautiful.widget_red}
         end
     end
-
-    mpdarc:connect_signal("button::press", function(_, _, _, button)
-        if (button == 1) then
-            awful.spawn(TOGGLE_MPD_CMD, false) -- left click
-        elseif (button == 2) then
-            awful.spawn(STOP_MPD_CMD, false)
-        elseif (button == 3) then
-            awful.spawn(PAUSE_MPD_CMD, false)
-        elseif (button == 4) then
-            awful.spawn(NEXT_MPD_CMD, false) -- scroll up
-        elseif (button == 5) then
-            awful.spawn(PREV_MPD_CMD, false) -- scroll down
-        end
-
-        -- spawn.easy_async(string.format(GET_MPD_CMD, "'" .. default_player .. "'"),
-        -- function(stdout, stderr, exitreason, exitcode)
-        --     update_graphic(mpdarc, stdout, stderr, exitreason, exitcode)
-        -- end)
-    end)
 
     mpris_widget:buttons(
             awful.util.table.join(

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -7,13 +7,11 @@
 -------------------------------------------------
 local awful = require("awful")
 local beautiful = require("beautiful")
-local spawn = require("awful.spawn")
 local watch = require("awful.widget.watch")
 local wibox = require("wibox")
-local naughty = require("naughty")
 local gears = require("gears")
 
-local GET_MPD_CMD = "playerctl -p %s -f '{{status}};{{xesam:artist}};{{xesam:title}};{{mpris:artUrl}}' metadata"
+local GET_MPD_CMD = "playerctl -p %s -f '{{status}};{{xesam:artist}};{{xesam:title}}' metadata"
 
 local TOGGLE_MPD_CMD = "playerctl play-pause"
 local NEXT_MPD_CMD = "playerctl next"
@@ -135,14 +133,13 @@ end
 local function worker()
 
     -- retrieve song info
-    local current_song, artist, player_status, artUrl
+    local current_song, artist, player_status
 
     local update_graphic = function(widget, stdout, _, _, _)
         local words = gears.string.split(stdout, ';')
         player_status = words[1]
         artist = words[2]
         current_song = words[3]
-        artUrl = words[4]
         if current_song ~= nil then
             if string.len(current_song) > 18 then
                 current_song = string.sub(current_song, 0, 9) .. ".."
@@ -180,29 +177,6 @@ local function worker()
                     awful.button({}, 1, function() awful.spawn(TOGGLE_MPD_CMD, false) end)
             )
     )
-
-
-
-    local notification
-    local function show_status()
-        spawn.easy_async(GET_MPD_CMD, function()
-            notification = naughty.notify {
-                margin = 10,
-                timeout = 5,
-                hover_timeout = 0.5,
-                width = 240,
-                height = 90,
-                title = player_status,
-                text = current_song .. " - " .. artist,
-                image = artUrl
-            }
-        end)
-    end
-
-    mpris_widget:connect_signal("mouse::enter", function()
-        if current_song ~= nil and artist ~= nil then show_status() end
-    end)
-    mpris_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
 
     watch(string.format(GET_MPD_CMD, "'" .. default_player .. "'"), 1, update_graphic, mpris_widget)
 

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -220,7 +220,7 @@ local function worker()
     local notification
     local function show_MPD_status()
         spawn.easy_async(GET_MPD_CMD, function()
-            notification = naughty.notification {
+            notification = naughty.notify {
                 margin = 10,
                 timeout = 5,
                 hover_timeout = 0.5,

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -135,23 +135,19 @@ end
 local function worker()
 
     -- retrieve song info
-    local current_song, artist, player_status, art, artUrl
+    local current_song, artist, player_status, artUrl
 
     local update_graphic = function(widget, stdout, _, _, _)
-        local words = {}
-        for w in stdout:gmatch("([^;]*);") do table.insert(words, w) end
-
+        local words = gears.string.split(stdout, ';')
         player_status = words[1]
         artist = words[2]
         current_song = words[3]
-        art = words[4]
+        artUrl = words[4]
         if current_song ~= nil then
             if string.len(current_song) > 18 then
                 current_song = string.sub(current_song, 0, 9) .. ".."
             end
         end
-
-        if art ~= nil then artUrl = string.sub(art, 8, -1) end
 
         if player_status == "Playing" then
             icon.image = PLAY_ICON_NAME

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -128,7 +128,7 @@ end
 local function worker()
 
     -- retrieve song info
-    local current_song, artist, mpdstatus, art, artUrl
+    local current_song, artist, player_status, art, artUrl
 
     local icon = wibox.widget {
         id = "icon",
@@ -159,11 +159,10 @@ local function worker()
     }
 
     local update_graphic = function(widget, stdout, _, _, _)
-        -- mpdstatus, artist, current_song = stdout:match("(%w+)%;+(.-)%;(.*)")
         local words = {}
         for w in stdout:gmatch("([^;]*);") do table.insert(words, w) end
 
-        mpdstatus = words[1]
+        player_status = words[1]
         artist = words[2]
         current_song = words[3]
         art = words[4]
@@ -175,19 +174,19 @@ local function worker()
 
         if art ~= nil then artUrl = string.sub(art, 8, -1) end
 
-        if mpdstatus == "Playing" then
+        if player_status == "Playing" then
             mpdarc_icon_widget.visible = true
             icon.image = PLAY_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
             mpdarc_current_song_widget.markup = current_song
             widget:set_text(artist, current_song)
-        elseif mpdstatus == "Paused" then
+        elseif player_status == "Paused" then
             mpdarc_icon_widget.visible = true
             icon.image = PAUSE_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
             mpdarc_current_song_widget.markup = current_song
             widget:set_text(artist, current_song)
-        elseif mpdstatus == "Stopped" then
+        elseif player_status == "Stopped" then
             mpdarc_icon_widget.visible = true
             icon.image = STOP_ICON_NAME
             mpdarc_current_song_widget.markup = ""
@@ -226,7 +225,7 @@ local function worker()
                 hover_timeout = 0.5,
                 width = 240,
                 height = 90,
-                title = "<b>" .. mpdstatus .. "</b>",
+                title = "<b>" .. player_status .. "</b>",
                 text = current_song .. " <b>by</b> " .. artist,
                 image = artUrl
             }

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -208,7 +208,7 @@ local function worker()
 
 
     local notification
-    local function show_MPD_status()
+    local function show_status()
         spawn.easy_async(GET_MPD_CMD, function()
             notification = naughty.notify {
                 margin = 10,
@@ -216,17 +216,17 @@ local function worker()
                 hover_timeout = 0.5,
                 width = 240,
                 height = 90,
-                title = "<b>" .. player_status .. "</b>",
-                text = current_song .. " <b>by</b> " .. artist,
+                title = player_status,
+                text = current_song .. " - " .. artist,
                 image = artUrl
             }
         end)
     end
 
-    mpdarc:connect_signal("mouse::enter", function()
-        if current_song ~= nil and artist ~= nil then show_MPD_status() end
+    mpris_widget:connect_signal("mouse::enter", function()
+        if current_song ~= nil and artist ~= nil then show_status() end
     end)
-    mpdarc:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
+    mpris_widget:connect_signal("mouse::leave", function() naughty.destroy(notification) end)
 
     watch(string.format(GET_MPD_CMD, "'" .. default_player .. "'"), 1, update_graphic, mpris_widget)
 

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -152,11 +152,6 @@ local function worker()
     }
 
     local mpdarc_icon_widget = wibox.container.mirror(mpdarc, {horizontal = true})
-    local mpdarc_current_song_widget = wibox.widget {
-        id = 'current_song',
-        widget = wibox.widget.textbox,
-        font = 'Play 10'
-    }
 
     local update_graphic = function(widget, stdout, _, _, _)
         local words = {}
@@ -178,22 +173,18 @@ local function worker()
             mpdarc_icon_widget.visible = true
             icon.image = PLAY_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
-            mpdarc_current_song_widget.markup = current_song
             widget:set_text(artist, current_song)
         elseif player_status == "Paused" then
             mpdarc_icon_widget.visible = true
             icon.image = PAUSE_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
-            mpdarc_current_song_widget.markup = current_song
             widget:set_text(artist, current_song)
         elseif player_status == "Stopped" then
             mpdarc_icon_widget.visible = true
             icon.image = STOP_ICON_NAME
-            mpdarc_current_song_widget.markup = ""
         else -- no player is running
             icon.image = LIBRARY_ICON_NAME
             mpdarc_icon_widget.visible = false
-            mpdarc_current_song_widget.markup = ""
             widget.colors = {beautiful.widget_red}
         end
     end

--- a/mpris-widget/init.lua
+++ b/mpris-widget/init.lua
@@ -28,12 +28,19 @@ local LIBRARY_ICON_NAME = PATH_TO_ICONS .. "/actions/24/music-library.png"
 
 local default_player = ''
 
+local icon = wibox.widget {
+    id = "icon",
+    widget = wibox.widget.imagebox,
+    image = PLAY_ICON_NAME
+}
+
 local mpris_widget = wibox.widget{
     {
         id = 'artist',
         widget = wibox.widget.textbox
     },
     {
+        icon,
         max_value = 1,
         value = 0,
         thickness = 2,
@@ -130,29 +137,6 @@ local function worker()
     -- retrieve song info
     local current_song, artist, player_status, art, artUrl
 
-    local icon = wibox.widget {
-        id = "icon",
-        widget = wibox.widget.imagebox,
-        image = PLAY_ICON_NAME
-    }
-    local mirrored_icon = wibox.container.mirror(icon, {horizontal = true})
-
-    local mpdarc = wibox.widget {
-        mirrored_icon,
-        -- max_value = 1,
-        -- value = 0,
-        thickness = 2,
-        start_angle = 4.71238898, -- 2pi*3/4
-        forced_height = 24,
-        forced_width = 24,
-        rounded_edge = true,
-        bg = "#ffffff11",
-        paddings = 0,
-        widget = wibox.container.arcchart
-    }
-
-    local mpdarc_icon_widget = wibox.container.mirror(mpdarc, {horizontal = true})
-
     local update_graphic = function(widget, stdout, _, _, _)
         local words = {}
         for w in stdout:gmatch("([^;]*);") do table.insert(words, w) end
@@ -170,21 +154,17 @@ local function worker()
         if art ~= nil then artUrl = string.sub(art, 8, -1) end
 
         if player_status == "Playing" then
-            mpdarc_icon_widget.visible = true
             icon.image = PLAY_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
             widget:set_text(artist, current_song)
         elseif player_status == "Paused" then
-            mpdarc_icon_widget.visible = true
             icon.image = PAUSE_ICON_NAME
             widget.colors = {beautiful.widget_main_color}
             widget:set_text(artist, current_song)
         elseif player_status == "Stopped" then
-            mpdarc_icon_widget.visible = true
             icon.image = STOP_ICON_NAME
         else -- no player is running
             icon.image = LIBRARY_ICON_NAME
-            mpdarc_icon_widget.visible = false
             widget.colors = {beautiful.widget_red}
         end
     end


### PR DESCRIPTION
This PR includes some improvements for the mpris-widget. Some of the more interesting changes are:
- it removes some copy pasted code from the widget this widget was built on
-  fixes selecting a default player (although my impression is that selecting a default player doesn't do anything useful yet)
- fixes an API call in code that is unused for now, but that I plan to play with an enable in the future.