### PR TITLE
feature: add brightnessctl to brightness-widget

### DIFF
--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -9,7 +9,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `type`| `arc` | The widget type. Could be `arc` or `icon_and_text` |
-| `program` | `light` | The program used to control the brightness, either 'light' or 'xbacklight'. |
+| `program` | `light` | The program used to control the brightness, either `light`, `xbacklight`, or `brightnessctl`. |
 | `step` | 5 | Step |
 | `base` | 20 | Base level to set brightness to on left click. |
 | `path_to_icon` | `/usr/share/icons/Arc/status/symbolic/display-brightness-symbolic.svg` | Path to the icon |
@@ -43,6 +43,13 @@ To choose the right `program` argument, first you need to check which of them wo
     light -A 5
     ```
     If you're on Ubuntu/debian and if the brightness level doesn't change, try to do this: https://github.com/haikarainen/light/issues/113#issuecomment-632638436.
+
+  - using `brightnessctl`:
+
+    On Ubuntu it is available in the apt repository. Install and check the ouptut of the following command.
+    ```bash
+    brightnessctl --list
+    ```
 
 Then clone this repo under **~/.config/awesome/**:
 

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -45,14 +45,19 @@ local function worker(user_args)
     local tooltip = args.tooltip or false
     if program == 'light' then
         get_brightness_cmd = 'light -G'
-        set_brightness_cmd = 'light -S ' -- <level>
+        set_brightness_cmd = 'light -S %d' -- <level>
         inc_brightness_cmd = 'light -A ' .. step
         dec_brightness_cmd = 'light -U ' .. step
     elseif program == 'xbacklight' then
         get_brightness_cmd = 'xbacklight -get'
-        set_brightness_cmd = 'xbacklight -set ' -- <level>
+        set_brightness_cmd = 'xbacklight -set %d' -- <level>
         inc_brightness_cmd = 'xbacklight -inc ' .. step
         dec_brightness_cmd = 'xbacklight -dec ' .. step
+    elseif program == 'brightnessctl' then
+        get_brightness_cmd = 'bash -c "brightnessctl -m | cut -d, -f4 | tr -d %"'
+        set_brightness_cmd = 'brightnessctl set %d%%' -- <level>
+        inc_brightness_cmd = 'brightnessctl set +' .. step .. '%'
+        dec_brightness_cmd = 'brightnessctl set ' .. step .. '-%'
     else
         show_warning(program .. " command is not supported by the widget")
         return
@@ -116,7 +121,7 @@ local function worker(user_args)
 
     function brightness_widget:set(value)
         current_level = value
-        spawn.easy_async(set_brightness_cmd .. value, function()
+        spawn.easy_async(string.format(set_brightness_cmd, value), function()
             spawn.easy_async(get_brightness_cmd, function(out)
                 update_widget(brightness_widget.widget, out)
             end)


### PR DESCRIPTION
I am running Arch Linux on a Thinkpad. In the brightness-widget both `light` and `xbacklight` do not work out of the box. For me `brightnessctl` works and this pull request adds the commands for `brightnessctl` to the brightness-widget.

---

Thanks for the awesome-wm-widgets!