### PR TITLE
volume-widget: add device parameter

### DIFF
--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -36,7 +36,7 @@ s.mytasklist, -- Middle widget
         },
 ```
 
-Note that widget uses following command the get the current volume: `amixer -D pulse sget Master`, so please make sure that it works for you, otherwise you need to install `pulseaudio-alsa` package.
+Note that widget uses following command the get the current volume: `amixer -D pulse sget Master`, so please make sure that it works for you, otherwise you need to set parameter `device = 'default'`.
 
 ### Shortcuts
 
@@ -59,6 +59,7 @@ It is possible to customize the widget by providing a table with all or some of 
 | `mixer_cmd` | `pavucontrol` | command to run on middle click (e.g. a mixer program) |
 | `step` | `5` | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
+| `device` | `pulse` | Select the device name to control |
 
 Depending on the chosen widget type add parameters from the corresponding section below:
 

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -17,10 +17,10 @@ local utils = require("awesome-wm-widgets.volume-widget.utils")
 
 
 local LIST_DEVICES_CMD = [[sh -c "pacmd list-sinks; pacmd list-sources"]]
-local GET_VOLUME_CMD = 'amixer -D pulse sget Master'
-local function INC_VOLUME_CMD(step) return 'amixer -D pulse sset Master ' .. step .. '%+' end
-local function DEC_VOLUME_CMD(step) return 'amixer -D pulse sset Master ' .. step .. '%-' end
-local TOG_VOLUME_CMD = 'amixer -D pulse sset Master toggle'
+local function GET_VOLUME_CMD(device) return 'amixer -D ' .. device .. ' sget Master' end
+local function INC_VOLUME_CMD(device, step) return 'amixer -D ' .. device .. ' pulse sset Master ' .. step .. '%+' end
+local function DEC_VOLUME_CMD(device, step) return 'amixer -D ' .. device .. ' pulse sset Master ' .. step .. '%-' end
+local function TOG_VOLUME_CMD(device) return 'amixer -D ' .. device .. ' sset Master toggle' end
 
 
 local widget_types = {
@@ -167,6 +167,7 @@ local function worker(user_args)
     local widget_type = args.widget_type
     local refresh_rate = args.refresh_rate or 1
     local step = args.step or 5
+    local device = args.device or 'pulse'
 
     if widget_types[widget_type] == nil then
         volume.widget = widget_types['icon_and_text'].get_widget(args.icon_and_text_args)
@@ -185,15 +186,15 @@ local function worker(user_args)
     end
 
     function volume:inc(s)
-        spawn.easy_async(INC_VOLUME_CMD(s or step), function(stdout) update_graphic(volume.widget, stdout) end)
+        spawn.easy_async(INC_VOLUME_CMD(device, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:dec(s)
-        spawn.easy_async(DEC_VOLUME_CMD(s or step), function(stdout) update_graphic(volume.widget, stdout) end)
+        spawn.easy_async(DEC_VOLUME_CMD(device, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:toggle()
-        spawn.easy_async(TOG_VOLUME_CMD, function(stdout) update_graphic(volume.widget, stdout) end)
+        spawn.easy_async(TOG_VOLUME_CMD(device), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:mixer()
@@ -219,7 +220,7 @@ local function worker(user_args)
             )
     )
 
-    watch(GET_VOLUME_CMD, refresh_rate, update_graphic, volume.widget)
+    watch(GET_VOLUME_CMD(device), refresh_rate, update_graphic, volume.widget)
 
     return volume.widget
 end


### PR DESCRIPTION
By default this widget uses pulse audio device. To make this widget
works ALSA users have to install third-party utils. This patch adds
ability to select device name for audio control.