### PR TITLE
Add option 'percentage' for brightness widget

### DIFF
--- a/brightness-widget/README.md
+++ b/brightness-widget/README.md
@@ -16,6 +16,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `font` | `Play 9` | Font |
 | `timeout` | 1 | How often in seconds the widget refreshes. Check the note below |
 | `tooltip` | false | Display brightness level in a tooltip when the mouse cursor hovers the widget |
+| `percentage` | false | Display a '%' character after the brightness level |
 
 _Note:_ If brightness is controlled only by the widget (either by a mouse, or by a shortcut, then the `timeout` could be quite big, as there is no reason to synchronize the brightness level).
 

--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -43,6 +43,7 @@ local function worker(user_args)
     local base = args.base or 20
     local current_level = 0 -- current brightness value
     local tooltip = args.tooltip or false
+    local percentage = args.percentage or false
     if program == 'light' then
         get_brightness_cmd = 'light -G'
         set_brightness_cmd = 'light -S %d' -- <level>
@@ -82,7 +83,11 @@ local function worker(user_args)
             spacing = 4,
             layout = wibox.layout.fixed.horizontal,
             set_value = function(self, level)
-                self:get_children_by_id('txt')[1]:set_text(level .. '%')
+                local display_level = level
+                if percentage then
+                    display_level = display_level .. '%'
+                end
+                self:get_children_by_id('txt')[1]:set_text(display_level)
             end
         }
     elseif type == 'arc' then


### PR DESCRIPTION
The brightness widget has a percentage character after the value, and others don't. As this is kind of annoying, I made an option to toggle it off.