### PR TITLE
Cmus widget - fix unused "spacing" option

### DIFF
--- a/cmus-widget/README.md
+++ b/cmus-widget/README.md
@@ -42,7 +42,7 @@ It is possible to customize the widget by providing a table with all or some of 
 
 | Name | Default | Description |
 |---|---|---|
-| `font` | `Play 9` | Font used for the track title |
+| `font` | `beautiful.font` | Font name and size, like `Play 12` |
 | `path_to_icons` | `/usr/share/icons/Arc/actions/symbolic/` | Alternative path for the icons |
 | `timeout`| `10` | Refresh cooldown |
 | `space` | `3` | Space between icon and track title |

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -14,13 +14,6 @@ local naughty = require("naughty")
 
 local cmus_widget = {}
 
-local function show_warning(message)
-    naughty.notify{
-        preset = naughty.config.presets.critical,
-        title = "Cmus Widget",
-        text = message}
-end
-
 local function worker(user_args)
 
     local args = user_args or {}
@@ -54,7 +47,7 @@ local function worker(user_args)
         end
     }
 
-    function update_widget(widget, stdout, _, _, code)
+    local function update_widget(widget, stdout, _, _, code)
         if code == 0 then
             local cmus_info = {}
 
@@ -64,12 +57,12 @@ local function worker(user_args)
                 if key and val then
                     cmus_info[key] = val
                 else
-                    local key, val = string.match(s, "^set (%a+) (.+)$")
+                    key, val = string.match(s, "^set (%a+) (.+)$")
 
                     if key and val then
                         cmus_info[key] = val
                     else
-                        local key, val = string.match(s, "^(%a+) (.+)$")
+                        key, val = string.match(s, "^(%a+) (.+)$")
                         if key and val then
                             cmus_info[key] = val
                         end

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -89,7 +89,6 @@ local function worker(user_args)
                 widget.visible = true
             else
                 widget.visible = false
-                widget.width = 0
             end
         else
             widget.visible = false

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -10,7 +10,6 @@ local awful = require("awful")
 local wibox = require("wibox")
 local watch = require("awful.widget.watch")
 local spawn = require("awful.spawn")
-local naughty = require("naughty")
 
 local cmus_widget = {}
 

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -44,6 +44,7 @@ local function worker(user_args)
             font = font,
             widget = wibox.widget.textbox
         },
+        spacing = space,
         layout = wibox.layout.fixed.horizontal,
         update_icon = function(self, name)
             self:get_children_by_id("playback_icon")[1]:set_image(path_to_icons .. name)

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -10,13 +10,14 @@ local awful = require("awful")
 local wibox = require("wibox")
 local watch = require("awful.widget.watch")
 local spawn = require("awful.spawn")
+local beautiful = require('beautiful')
 
 local cmus_widget = {}
 
 local function worker(user_args)
 
     local args = user_args or {}
-    local font = args.font or "Play 9"
+    local font = args.font or beautiful.font
 
     local path_to_icons = args.path_to_icons or "/usr/share/icons/Arc/actions/symbolic/"
     local timeout = args.timeout or 10


### PR DESCRIPTION
I forgot to include the spacing option. Also fixed warnings.