### PR TITLE
Add customizations to batteryarc and ram widgets.

### DIFF
--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -39,6 +39,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `warning_msg_icon` | ~/.config/awesome/awesome-wm-widgets/batteryarc-widget/spaceman.jpg | Icon of the warning popup |
 | `enable_battery_warning` | `true` | Display low battery warning |
 | `show_notification_mode` | `on_hover` | How to trigger a notification with the battery status: `on_hover`, `on_click` or `off`  |
+| `notification_position` | `top_left` | Where to show she notification when triggered. Values: `top_right`, `top_left`, `bottom_left`, `bottom_right`, `top_middle`, `bottom_middle`. (default `top_right`) |
 
 ## Requirements
 

--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -29,6 +29,7 @@ local function worker(user_args)
     local size = args.size or 18
     local timeout = args.timeout or 10
     local show_notification_mode = args.show_notification_mode or 'on_hover' -- on_hover / on_click
+    local notification_position = args.notification_position or 'top_right' -- see naughty.notify position argument
 
     local main_color = args.main_color or beautiful.fg_color
     local bg_color = args.bg_color or '#ffffff11'
@@ -146,6 +147,7 @@ local function worker(user_args)
                         title = "Battery status",
                         timeout = 5,
                         width = 200,
+                        position = notification_position,
                     }
                 end)
     end

--- a/ram-widget/README.md
+++ b/ram-widget/README.md
@@ -15,6 +15,8 @@ It is possible to customize widget by providing a table with all or some of the 
 | `color_used` | `beautiful.bg_urgent` | Color for used RAM |
 | `color_free` | `beautiful.fg_normal` | Color for free RAM |
 | `color_buf`  | `beautiful.border_color_active` | Color for buffers/cache |
+| `widget_height` | `25` | Height of the widget |
+| `widget_width` | `25` | Width of the widget |
 | `widget_show_buf`  | `false` | Whether to display buffers/cache separately in the tray widget. If `false`, buffers/cache are considered free RAM. |
 | `timeout`    | 1 | How often (in seconds) the widget refreshes |
 

--- a/ram-widget/ram-widget.lua
+++ b/ram-widget/ram-widget.lua
@@ -15,6 +15,8 @@ local function worker(user_args)
     local color_free = args.color_free or beautiful.fg_normal
     local color_buf  = args.color_buf  or beautiful.border_color_active
     local widget_show_buf = args.widget_show_buf or false
+    local widget_height = args.widget_height or 25
+    local widget_width = args.widget_width or 25
 
     --- Main ram widget shown on wibar
     ramgraph_widget = wibox.widget {
@@ -25,7 +27,8 @@ local function worker(user_args)
            color_buf,
         },
         display_labels = false,
-        forced_width = 25,
+        forced_height = widget_height,
+        forced_width = widget_width,
         widget = wibox.widget.piechart
     }
 


### PR DESCRIPTION
- Add notification_position parameters to batteryarc-widget.
- Add widget_height and widget_width parameters to ram-widget.

I run a top-bar for my tag-list, task-list, and a notification tray, and a left-bar for widgets and launchers.

For the battery arc, the hover-over menu was showing up on the opposite side of the screen from the mouse, which was a little jarring. This lets me set it to be something more sane for my layout.

For the ram widget, without setting the height it was expanding and taking up the whole bar length. This let me set it to an arbitrary height. Not sure if this will change the default appearance if it is used in a top or bottom bar.