### PR TITLE
Allow specifying a custom location for the sp binary used by spotify-widget

### DIFF
--- a/spotify-widget/README.md
+++ b/spotify-widget/README.md
@@ -34,6 +34,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `max_length` | `15` | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
 | `show_tooltip` | `true` | Show tooltip on hover with information about the playing song |
 | `timeout` | 1 | How often in seconds the widget refreshes |
+| `sp_bin` | `sp` | Path to the `sp` binary. Required if `sp` is not in environment PATH. |
 
 
 ### Example:
@@ -46,7 +47,8 @@ spotify_widget({
     dim_when_paused = true,
     dim_opacity = 0.5,
     max_length = -1,
-    show_tooltip = false
+    show_tooltip = false,
+    sp_bin = gears.filesystem.get_configuration_dir() .. 'scripts/sp'
 })
 ```
 
@@ -66,7 +68,10 @@ First you need to have spotify CLI installed, it uses dbus to communicate with s
 git clone https://gist.github.com/fa6258f3ff7b17747ee3.git
 cd ./fa6258f3ff7b17747ee3 
 chmod +x sp
+# This widget will work by default if the binary is in the system PATH
 sudo cp ./sp /usr/local/bin/
+# Alternatively, you may save the binary anywhere and supply the path via this widget's sp_bin argument:
+# cp ./sp ~/.config/awesome/scripts/
 ```
 
 Then clone repo under **~/.config/awesome/** and add widget in **rc.lua**:

--- a/spotify-widget/spotify.lua
+++ b/spotify-widget/spotify.lua
@@ -12,9 +12,6 @@ local awful = require("awful")
 local wibox = require("wibox")
 local watch = require("awful.widget.watch")
 
-local GET_SPOTIFY_STATUS_CMD = 'sp status'
-local GET_CURRENT_SONG_CMD = 'sp current'
-
 local function ellipsize(text, length)
     -- utf8 only available in Lua 5.3+
     if utf8 == nil then
@@ -39,6 +36,10 @@ local function worker(user_args)
     local max_length = args.max_length or 15
     local show_tooltip = args.show_tooltip == nil and true or args.show_tooltip
     local timeout = args.timeout or 1
+    local sp_bin = args.sp_bin or 'sp'
+
+    local GET_SPOTIFY_STATUS_CMD = sp_bin .. ' status'
+    local GET_CURRENT_SONG_CMD = sp_bin .. ' current'
 
     local cur_artist = ''
     local cur_title = ''


### PR DESCRIPTION
Provides a new widget configuration option for spotify-widget called `sp_bin`. It may be used to specify a custom location for the `sp` binary, rather than attempting to use the system PATH. See [updated README](https://github.com/chaorace/awesome-wm-widgets/blob/5d50fe7fab8dcfcf649bafdcd4197219b76bc0b9/spotify-widget/README.md) for full documentation and a usage example

This is intended for those users who don't want to add the sp binary to their PATH or simply want to make their configuration more portable. 