### PR TITLE
Allow specifying the maximum song title length before scrolling begins in spotify-widget

### DIFF
--- a/spotify-widget/README.md
+++ b/spotify-widget/README.md
@@ -32,6 +32,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `dim_when_paused` | `false` | Decrease the widget opacity if spotify is paused |
 | `dim_opacity` | `0.2` | Widget's opacity when dimmed, `dim_when_paused` should be set to `true` |
 | `max_length` | `15` | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
+| `title_scroll_length` | `100` | Maximum length of title name before it begins scrolling. -1 prevents scrolling entirely. |
 | `show_tooltip` | `true` | Show tooltip on hover with information about the playing song |
 | `timeout` | 1 | How often in seconds the widget refreshes |
 

--- a/spotify-widget/README.md
+++ b/spotify-widget/README.md
@@ -31,7 +31,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | `font` | `Play 9`| Font |
 | `dim_when_paused` | `false` | Decrease the widget opacity if spotify is paused |
 | `dim_opacity` | `0.2` | Widget's opacity when dimmed, `dim_when_paused` should be set to `true` |
-| `max_length` | `15` | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
+| `max_length` | `15` | Maximum length of the artist and title name labels before ellipsizing. -1 prevents ellipsizing entirely. |
 | `title_scroll_length` | `100` | Maximum length of title name before it begins scrolling. -1 prevents scrolling entirely. |
 | `show_tooltip` | `true` | Show tooltip on hover with information about the playing song |
 | `timeout` | 1 | How often in seconds the widget refreshes |

--- a/spotify-widget/spotify.lua
+++ b/spotify-widget/spotify.lua
@@ -37,12 +37,35 @@ local function worker(user_args)
     local dim_when_paused = args.dim_when_paused == nil and false or args.dim_when_paused
     local dim_opacity = args.dim_opacity or 0.2
     local max_length = args.max_length or 15
+    local title_scroll_length = args.title_scroll_length or 100
     local show_tooltip = args.show_tooltip == nil and true or args.show_tooltip
     local timeout = args.timeout or 1
 
     local cur_artist = ''
     local cur_title = ''
     local cur_album = ''
+
+    local title_widget = (function()
+            if title_scroll_length >= 0 then
+                return {
+                    layout = wibox.container.scroll.horizontal,
+                    max_size = title_scroll_length,
+                    step_function = wibox.container.scroll.step_functions.waiting_nonlinear_back_and_forth,
+                    speed = 40,
+                    {
+                        id = 'titlew',
+                        font = font,
+                        widget = wibox.widget.textbox
+                    }
+                }
+            else
+                return {
+                    id = 'titlew',
+                    font = font,
+                    widget = wibox.widget.textbox
+                }
+            end
+    end)()
 
     spotify_widget = wibox.widget {
         {
@@ -54,17 +77,7 @@ local function worker(user_args)
             id = "icon",
             widget = wibox.widget.imagebox,
         },
-        {
-            layout = wibox.container.scroll.horizontal,
-            max_size = 100,
-            step_function = wibox.container.scroll.step_functions.waiting_nonlinear_back_and_forth,
-            speed = 40,
-            {
-                id = 'titlew',
-                font = font,
-                widget = wibox.widget.textbox
-            }
-        },
+        title_widget,
         layout = wibox.layout.align.horizontal,
         set_status = function(self, is_playing)
             self.icon.image = (is_playing and play_icon or pause_icon)


### PR DESCRIPTION
Allows specifying a max title length via a new `title_scroll_length` option before spotify-widget begins scrolling it. If -1 is specified, the widget will never scroll (this is also how the pre-existing `max_length` configuration option works works). The originally hardcoded maximum scroll area width has been retained as the default option value.

Note that **only** the song _title_ is ever scrolled by the widget (this is the pre-existing behavior) and so only the length of the title will count towards the scroll area length.
