### PR TITLE
Separate artist/title textboxes in spotify-widget when an icon cannot be drawn

### DIFF
--- a/spotify-widget/spotify.lua
+++ b/spotify-widget/spotify.lua
@@ -51,8 +51,17 @@ local function worker(user_args)
             widget = wibox.widget.textbox,
         },
         {
-            id = "icon",
-            widget = wibox.widget.imagebox,
+            layout = wibox.layout.stack,
+            {
+                id = "icon",
+                widget = wibox.widget.imagebox,
+            },
+            {
+                widget = wibox.widget.textbox,
+                font = font,
+                text = ' ',
+                forced_height = 1
+            }
         },
         {
             layout = wibox.container.scroll.horizontal,


### PR DESCRIPTION
This PR introduces a minimum distance between the artist/title textboxes equal in width to 1 space character in the specified widget font.

The benefit of doing this is that the song artist/title will not get jumbled together in the event that the icon could not be drawn. This change should have no impact on most configurations that correctly specify an icon, because those icons will already have widths greater than 1 text character. In those cases, the layout appearance should be 100% identical to that of prior to the change.