### PR TITLE
fix: #281

### DIFF
--- a/logout-menu-widget/logout-menu.lua
+++ b/logout-menu-widget/logout-menu.lua
@@ -133,4 +133,4 @@ local function worker(user_args)
 
 end
 
-return setmetatable(logout_menu_widget, { __call = function(_, ...) return worker(...) end })
+return worker


### PR DESCRIPTION
This is a small fix to make the widget work with awesome git version.

The idea here is that the `setmetatable` operation exposes an instance of `logout_menu_widget` with a custom metatable. So it overrides the metatable-magic we have in awesome to backport the `:buttons` methods.

I think that to expose the `worker` (aka widget builder) function is good enough for most use case.

The advantages from the "`setmetatable` pattern" used by awesome wm widgets is that we can expose module level properties/functions (aka static members), and make the exposed table callable. AFAICT, there is no module level members that we need to be exposed here. We only want to have a callable module. So exposing the `worker` function itself it what we want.

(On another note: I have also started to work on a refactor of the widget with the WIP branch at https://github.com/Aire-One/awesome-wm-widgets/tree/fix/281-refactor. It's not yet ready, and it applies a lot of changes regarding the way the code is designed. So I'm not too much in to force its way to be merged now.)