### PR TITLE
Fix luacheck warnings

### DIFF
--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -57,10 +57,10 @@ local function worker(user_args)
         inc_brightness_cmd = 'xbacklight -inc ' .. step
         dec_brightness_cmd = 'xbacklight -dec ' .. step
     elseif program == 'brightnessctl' then
-  	get_brightness_cmd = "brightnessctl get"
-		set_brightness_cmd = "brightnessctl set %d%%" -- <level>
-		inc_brightness_cmd = "brightnessctl set +" .. step .. "%"
-		dec_brightness_cmd = "brightnessctl set " .. step .. "-%"  
+        get_brightness_cmd = "brightnessctl get"
+        set_brightness_cmd = "brightnessctl set %d%%" -- <level>
+        inc_brightness_cmd = "brightnessctl set +" .. step .. "%"
+        dec_brightness_cmd = "brightnessctl set " .. step .. "-%"
     else
         show_warning(program .. " command is not supported by the widget")
         return


### PR DESCRIPTION
This patch fixes luacheck warnings in brightness plugin:
brightness-widget/brightness.lua:60:1:
        inconsistent indentation (SPACE followed by TAB)
brightness-widget/brightness.lua:63:60:
        line contains trailing whitespace