### PR TITLE
feat volume: let all widgets read args for the icon_dir

### DIFF
--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -60,14 +60,9 @@ It is possible to customize the widget by providing a table with all or some of 
 | `step` | `5` | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
 | `device` | `pulse` | Select the device name to control |
+| `icon_dir`| `./icons`| Path to the folder with icons | 
 
 Depends on the chosen widget type add parameters from the corresponding section below:
-
-#### `icon` parameters
-
-| Name | Default | Description |
-|---|---|---|
-| `icon_dir`| `./icons`| Path to the folder with icons | 
 
 _Note:_ if you are changing icons, the folder should contain following .svg images: 
  - audio-volume-high-symbolic
@@ -75,11 +70,14 @@ _Note:_ if you are changing icons, the folder should contain following .svg imag
  - audio-volume-low-symbolic
  - audio-volume-muted-symbolic
 
+#### `icon` parameters
+
+(None)
+
 #### `icon_and_text` parameters
 
 | Name | Default | Description |
 |---|---|---|
-| `icon_dir`| `./icons`| Path to the folder with icons | 
 | `font` | `beautiful.font` | Font name and size, like `Play 12` |
 
 #### `arc` parameters

--- a/volume-widget/widgets/arc-widget.lua
+++ b/volume-widget/widgets/arc-widget.lua
@@ -13,11 +13,12 @@ function widget.get_widget(widgets_args)
     local bg_color = args.bg_color or '#ffffff11'
     local mute_color = args.mute_color or beautiful.fg_urgent
     local size = args.size or 18
+    local icon_dir = args.icon_dir or ICON_DIR
 
     return wibox.widget {
         {
             id = "icon",
-            image = ICON_DIR .. 'audio-volume-high-symbolic.svg',
+            image = icon_dir .. 'audio-volume-high-symbolic.svg',
             resize = true,
             widget = wibox.widget.imagebox,
         },

--- a/volume-widget/widgets/horizontal-bar-widget.lua
+++ b/volume-widget/widgets/horizontal-bar-widget.lua
@@ -16,12 +16,13 @@ function widget.get_widget(widgets_args)
     local margins = args.margins or 10
     local shape = args.shape or 'bar'
     local with_icon = args.with_icon == true and true or false
+    local icon_dir = args.icon_dir or ICON_DIR
 
     local bar = wibox.widget {
         {
             {
                 id = "icon",
-                image = ICON_DIR .. 'audio-volume-high-symbolic.svg',
+                image = icon_dir .. 'audio-volume-high-symbolic.svg',
                 resize = false,
                 widget = wibox.widget.imagebox,
             },

--- a/volume-widget/widgets/vertical-bar-widget.lua
+++ b/volume-widget/widgets/vertical-bar-widget.lua
@@ -16,12 +16,13 @@ function widget.get_widget(widgets_args)
     local margins = args.height or 2
     local shape = args.shape or 'bar'
     local with_icon = args.with_icon == true and true or false
+    local icon_dir = args.icon_dir or ICON_DIR
 
     local bar = wibox.widget {
         {
             {
                 id = "icon",
-                image = ICON_DIR .. 'audio-volume-high-symbolic.svg',
+                image = icon_dir .. 'audio-volume-high-symbolic.svg',
                 resize = false,
                 widget = wibox.widget.imagebox,
             },


### PR DESCRIPTION
For people like me who use a standalone repo to hold the configurations and have the widgets repo as a submodule, it may be better to have the ability to reset the paths for the assets.
