### PR TITLE
Copy ellipsize function from Spotify widget

### DIFF
--- a/cmus-widget/README.md
+++ b/cmus-widget/README.md
@@ -36,7 +36,7 @@ awful.key({                 }, "XF86AudioPlay",  function () cmus_widget:play() 
 awful.key({                 }, "XF86AudioPause", function () cmus_widget:play()       end, {description = "pause track",    group = "cmus"}),
 awful.key({                 }, "XF86AudioNext",  function () cmus_widget:next_track() end, {description = "next track",     group = "cmus"}),
 awful.key({                 }, "XF86AudioPrev",  function () cmus_widget:prev_track() end, {description = "previous track", group = "cmus"}),
-awful.key({                 }, "XF86AudioStop",  function () cmus_widget:stop()       end, {description = "stop cmus",      group = "cmus"}),
+awful.key({                 }, "XF86AudioStop",  function () cmus_widget:stop()       end, {description = "stop track",      group = "cmus"}),
 ```
 
 ## Customization
@@ -50,4 +50,5 @@ It is possible to customize the widget by providing a table with all or some of 
 | `font` | `beautiful.font` | Font name and size, like `Play 12` |
 | `path_to_icons` | `/usr/share/icons/Arc/actions/symbolic/` | Alternative path for the icons |
 | `timeout`| `10` | Refresh cooldown |
+| `max_length` | `30` | Maximum lentgh of title. Text will be ellipsized if longer. |
 | `space` | `3` | Space between icon and track title |

--- a/cmus-widget/cmus.lua
+++ b/cmus-widget/cmus.lua
@@ -12,6 +12,16 @@ local watch = require("awful.widget.watch")
 local spawn = require("awful.spawn")
 local beautiful = require('beautiful')
 
+local function ellipsize(text, length)
+    -- utf8 only available in Lua 5.3+
+    if utf8 == nil then
+        return text:sub(0, length)
+    end
+    return (utf8.len(text) > length and length > 0)
+        and text:sub(0, utf8.offset(text, length - 2) - 1) .. '...'
+        or text
+end
+
 local cmus_widget = {}
 
 local function worker(user_args)
@@ -21,6 +31,7 @@ local function worker(user_args)
 
     local path_to_icons = args.path_to_icons or "/usr/share/icons/Arc/actions/symbolic/"
     local timeout = args.timeout or 10
+    local max_length = args.max_length or 30
     local space = args.space or 3
 
     cmus_widget.widget = wibox.widget {
@@ -86,7 +97,7 @@ local function worker(user_args)
                     widget:update_icon("media-playback-stop-symbolic.svg")
                 end
 
-                widget:set_title(title)
+                widget:set_title(ellipsize(title, max_length))
                 widget.visible = true
             else
                 widget.visible = false


### PR DESCRIPTION
I copied this function from the Spotify widget to ellipse the track's title when it's too long.