### PR TITLE
Fix ps: 'improper AIX field descriptor'

### DIFF
--- a/cpu-widget/cpu-widget.lua
+++ b/cpu-widget/cpu-widget.lua
@@ -14,8 +14,8 @@ local wibox = require("wibox")
 local beautiful = require("beautiful")
 local gears = require("gears")
 
-local CMD = [[sh -c "grep '^cpu.' /proc/stat; ps -eo '%p|%c|%C|' -o "%mem" -o '|%a' --sort=-%cpu ]]
-    .. [[| head -11 | tail -n +2"]]
+local CMD = [[sh -c "grep '^cpu.' /proc/stat; ps -eo 'pid:10,pcpu:5,pmem:5,comm:30,cmd' --sort=-pcpu ]]
+    .. [[| grep -v [p]s | grep -v [g]rep | head -11 | tail -n +2"]]
 
 -- A smaller command, less resource intensive, used when popup is not shown.
 local CMD_slim = [[grep --max-count=1 '^cpu.' /proc/stat]]
@@ -33,17 +33,9 @@ local process_rows = {
     layout = wibox.layout.fixed.vertical,
 }
 
--- Splits the string by separator
--- @return table with separated substrings
-local function split(string_to_split, separator)
-    if separator == nil then separator = "%s" end
-    local t = {}
-
-    for str in string.gmatch(string_to_split, "([^".. separator .."]+)") do
-        table.insert(t, str)
-    end
-
-    return t
+-- Remove spaces at end and beggining of a string
+function trim(s)
+   return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
 -- Checks if a string starts with a another string
@@ -242,13 +234,11 @@ local function worker(user_args)
                 else
                     if is_update == true then
 
-                        local columns = split(line, '|')
-
-                        local pid = columns[1]
-                        local comm = columns[2]
-                        local cpu = columns[3]
-                        local mem = columns[4]
-                        local cmd = columns[5]
+                        local pid = trim(string.sub(line, 1, 10))
+                        local cpu = trim(string.sub(line, 12, 16))
+                        local mem = trim(string.sub(line, 18, 22))
+                        local comm = trim(string.sub(line, 24, 53))
+                        local cmd = trim(string.sub(line, 54))
 
                         local kill_proccess_button = enable_kill_button and create_kill_process_button() or nil
 


### PR DESCRIPTION
It appears that `ps` doesn't support using custom separators (e.g. here: '|') on all OSes. This replaces it with hardcoded lengths when known (cpu, mem, etc...).

E.G. on a debian bookworm machine this is what it returns:
```
ps -eo '%p|%c|%C|' -o "%mem" -o '|%a' --sort=-%cpu
error: improper AIX field descriptor
```