### PR TITLE
Added displaying volume in tooltip

### DIFF
--- a/pactl-widget/README.md
+++ b/pactl-widget/README.md
@@ -49,6 +49,7 @@ the following config parameters:
 | `step` | `5` | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
 | `device` | `@DEFAULT_SINK@` | Select the device name to control |
+| `tooltip` | `false` | Display volume level in a tooltip when the mouse cursor hovers the widget |
 
 For more details on parameters depending on the chosen widget type, please
 refer to the original Volume widget.

--- a/pactl-widget/volume.lua
+++ b/pactl-widget/volume.lua
@@ -157,6 +157,7 @@ local function worker(user_args)
     local refresh_rate = args.refresh_rate or 1
     local step = args.step or 5
     local device = args.device or '@DEFAULT_SINK@'
+    local tooltip = args.tooltip or false
 
     if widget_types[widget_type] == nil then
         volume.widget = widget_types['icon_and_text'].get_widget(args.icon_and_text_args)
@@ -225,6 +226,15 @@ local function worker(user_args)
             update_graphic(volume.widget)
         end
     }
+
+    if tooltip then
+        awful.tooltip {
+            objects        = { volume.widget },
+            timer_function = function()
+                return pactl.get_volume(device) .. " %"
+            end,
+        }
+    end
 
     return volume.widget
 end


### PR DESCRIPTION
Added ability to check volume in a tooltip for pactl-widget, as in brightness-widget. that's convenient for viewing the exact volume level when pactl-widget is in arc mode.