### PR TITLE
add hide on leave feature

### DIFF
--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -60,6 +60,7 @@ Then
 | `text_color` | `beautiful.fg_normal` | The color of text |
 | `label_color` | `beautiful.fg_normal` | The color of the button's label |
 | `phrases` | `{'Goodbye!'}` | The table with phrase(s) to show, if more than one provided, the phrase is chosen randomly. Leave empty (`{}`) to hide the phrase |
+| `hide_on_leave` | `false` | If the popup should be hidden when the mouse leaves it |
 | `onlogout` | `function() awesome.quit() end` | Function which is called when the logout button is pressed |
 | `onlock` | `function() awful.spawn.with_shell("systemctl suspend") end` | Function which is called when the lock button is pressed |
 | `onreboot` | `function() awful.spawn.with_shell("reboot") end` | Function which is called when the reboot button is pressed |

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -73,6 +73,7 @@ local function launch(args)
     local phrases = args.phrases or {'Goodbye!'}
     local icon_size = args.icon_size or 40
     local icon_margin = args.icon_margin or 16
+    local hide_on_leave = args.hide_on_leave or false
 
     local onlogout = args.onlogout or function () awesome.quit() end
     local onlock = args.onlock or function() awful.spawn.with_shell("i3lock") end
@@ -124,6 +125,13 @@ local function launch(args)
 
     w.screen = mouse.screen
     w.visible = true
+    if hide_on_leave then
+        w:connect_signal("mouse::leave", function()
+            phrase_widget:set_text('')
+            capi.keygrabber.stop()
+            w.visible = false
+        end)
+    end
 
     awful.placement.centered(w)
     capi.keygrabber.run(function(_, key, event)


### PR DESCRIPTION
adds a switch to hide the popup when the mouse leaves it.

useful when calling the popup from somewhere other than the keybind or the widget.