### PR TITLE
awesome: wibox.widget.background has been renamed to wibox.container.…

### DIFF
--- a/pacman-widget/pacman.lua
+++ b/pacman-widget/pacman.lua
@@ -241,7 +241,7 @@ local function worker(user_args)
                         layout = wibox.container.margin
                     },
                     bg = _config.popup_bg_color,
-                    layout = wibox.widget.background
+                    layout = wibox.container.background
                 },
                 forced_width = _config.popup_width,
                 layout = wibox.layout.fixed.horizontal


### PR DESCRIPTION


Fixes the following warning
```
2023-05-21 13:03:02 W: awesome: wibox.widget.background has been renamed to wibox.container.background. stack traceback:
	/usr/share/awesome/lib/gears/debug.lua:113: in function 'gears.debug.deprecate'
	/usr/share/awesome/lib/gears/debug.lua:164: in local 'layout'
	/usr/share/awesome/lib/wibox/widget/base.lua:745: in upvalue 'drill'
	/usr/share/awesome/lib/wibox/widget/base.lua:778: in upvalue 'drill'
	/usr/share/awesome/lib/wibox/widget/base.lua:818: in function 'wibox.setup'
	...nfig/awesome/awesome-wm-widgets/pacman-widget/pacman.lua:227: in upvalue 'callback'
	/usr/share/awesome/lib/awful/widget/watch.lua:88: in function </usr/share/awesome/lib/awful/widget/watch.lua:87>
```