### PR TITLE
Be able to use "volume widget" (arc version) when cloned with custom folder name

### DIFF
--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -13,8 +13,9 @@ local spawn = require("awful.spawn")
 local gears = require("gears")
 local beautiful = require("beautiful")
 local watch = require("awful.widget.watch")
-local utils = require("awesome-wm-widgets.volume-widget.utils")
 
+local this_library_path = (...):match("(.-)[^%.]+$")
+local utils = require(this_library_path .. "utils")
 
 local LIST_DEVICES_CMD = [[sh -c "pacmd list-sinks; pacmd list-sources"]]
 local function GET_VOLUME_CMD(device) return 'amixer -D ' .. device .. ' sget Master' end
@@ -24,11 +25,11 @@ local function TOG_VOLUME_CMD(device) return 'amixer -D ' .. device .. ' sset Ma
 
 
 local widget_types = {
-    icon_and_text = require("awesome-wm-widgets.volume-widget.widgets.icon-and-text-widget"),
-    icon = require("awesome-wm-widgets.volume-widget.widgets.icon-widget"),
-    arc = require("awesome-wm-widgets.volume-widget.widgets.arc-widget"),
-    horizontal_bar = require("awesome-wm-widgets.volume-widget.widgets.horizontal-bar-widget"),
-    vertical_bar = require("awesome-wm-widgets.volume-widget.widgets.vertical-bar-widget")
+    icon_and_text = require(this_library_path .. "widgets.icon-and-text-widget"),
+    icon = require(this_library_path .. "widgets.icon-widget"),
+    arc = require(this_library_path .. "widgets.arc-widget"),
+    horizontal_bar = require(this_library_path .. "widgets.horizontal-bar-widget"),
+    vertical_bar = require(this_library_path .. "widgets.vertical-bar-widget")
 }
 local volume = {}
 

--- a/volume-widget/widgets/arc-widget.lua
+++ b/volume-widget/widgets/arc-widget.lua
@@ -13,11 +13,12 @@ function widget.get_widget(widgets_args)
     local bg_color = args.bg_color or '#ffffff11'
     local mute_color = args.mute_color or beautiful.fg_urgent
     local size = args.size or 18
+    local icon = args.icon or ICON_DIR .. 'audio-volume-high-symbolic.svg'
 
     return wibox.widget {
         {
             id = "icon",
-            image = ICON_DIR .. 'audio-volume-high-symbolic.svg',
+            image = icon,
             resize = true,
             widget = wibox.widget.imagebox,
         },


### PR DESCRIPTION
This change allow to use "volume widget" (arc version) when repository cloned with custom name.