### PR TITLE
Fix inconsistencies/typos in the documentation (mainly in tables)

### DIFF
--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -21,19 +21,19 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `font` | Play 8 | Fond |
+| `font` | `Play 8` | Font |
 | `path_to_icons` | `/usr/share/icons/Arc/status/symbolic/` | Path to the folder with icons* |
 | `show_current_level`| false | Show current charge level |
 | `margin_right`|0| The right margin of the widget|
 | `margin_left`|0| The left margin of the widget|
-| `display_notification` | `false` | Display a notification on mouseover |
+| `display_notification` | false | Display a notification on mouseover |
 | `notification_position` | `top_right` | The notification position |
 | `timeout` | 10 | How often in seconds the widget refreshes |
-| `warning_msg_title` | _Huston, we have a problem_ | Title of the warning popup |
-| `warning_msg_text` | _Battery is dying_ | Text of the warning popup |
+| `warning_msg_title` | `Huston, we have a problem` | Title of the warning popup |
+| `warning_msg_text` | `Battery is dying` | Text of the warning popup |
 | `warning_msg_position` | `bottom_right` | Position of the warning popup |
-| `warning_msg_icon` | ~/.config/awesome/awesome-wm-widgets/battery-widget/spaceman.jpg | Icon of the warning popup |
-| `enable_battery_warning` | `true` | Display low battery warning |
+| `warning_msg_icon` | `~/.config/awesome/awesome-wm-widgets/battery-widget/spaceman.jpg` | Icon of the warning popup |
+| `enable_battery_warning` | true | Display low battery warning |
 
 *Note: the widget expects following icons to be present in the folder:
 

--- a/batteryarc-widget/README.md
+++ b/batteryarc-widget/README.md
@@ -23,7 +23,7 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `font` | Play 6 | Font |
+| `font` | `Play 6` | Font |
 | `arc_thickness` | 2 | Thickness of the arc |
 | `show_current_level`| false | Show current charge level |
 | `size`| 18 | Size of the widget |
@@ -33,11 +33,11 @@ It is possible to customize widget by providing a table with all or some of the 
 | `low_level_color` | `#e53935` | Arc color when battery charge is less that 15% |
 | `medium_level_color` | `#c0ca33` |  Arc color when battery charge is between 15% and 40% |
 | `charging_color` | `#43a047` |  Color of the circle inside the arc when charging  |
-| `warning_msg_title` | _Huston, we have a problem_ | Title of the warning popup |
-| `warning_msg_text` | _Battery is dying_ | Text of the warning popup |
+| `warning_msg_title` | `Huston, we have a problem_` | Title of the warning popup |
+| `warning_msg_text` | `Battery is dying` | Text of the warning popup |
 | `warning_msg_position` | `bottom_right` | Position of the warning popup |
-| `warning_msg_icon` | ~/.config/awesome/awesome-wm-widgets/batteryarc-widget/spaceman.jpg | Icon of the warning popup |
-| `enable_battery_warning` | `true` | Display low battery warning |
+| `warning_msg_icon` | `~/.config/awesome/awesome-wm-widgets/batteryarc-widget/spaceman.jpg` | Icon of the warning popup |
+| `enable_battery_warning` | true | Display low battery warning |
 | `show_notification_mode` | `on_hover` | How to trigger a notification with the battery status: `on_hover`, `on_click` or `off`  |
 | `notification_position` | `top_left` | Where to show she notification when triggered. Values: `top_right`, `top_left`, `bottom_left`, `bottom_right`, `top_middle`, `bottom_middle`. (default `top_right`) |
 

--- a/bitbucket-widget/README.md
+++ b/bitbucket-widget/README.md
@@ -15,8 +15,8 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `icon` | `~/.config/awesome/awesome-wm-widgets/bitbucket-widget/bitbucket-icon-gradient-blue.svg` | Path to the icon |
-| `host` | Required | e.g _http://api.bitbucket.org_ |
-| `uuid` | Required | e.g _{123e4567-e89b-12d3-a456-426614174000}_ |
+| `host` | Required | e.g. _http://api.bitbucket.org_ |
+| `uuid` | Required | e.g. _{123e4567-e89b-12d3-a456-426614174000}_ |
 | `workspace` | Required | Workspace ID|
 | `repo_slug` | Required | Repository slug |
 | `timeout` | 60 | How often in seconds the widget refreshes |

--- a/cmus-widget/README.md
+++ b/cmus-widget/README.md
@@ -49,6 +49,6 @@ It is possible to customize the widget by providing a table with all or some of 
 |---|---|---|
 | `font` | `beautiful.font` | Font name and size, like `Play 12` |
 | `path_to_icons` | `/usr/share/icons/Arc/actions/symbolic/` | Alternative path for the icons |
-| `timeout`| `10` | Refresh cooldown |
-| `max_length` | `30` | Maximum lentgh of title. Text will be ellipsized if longer. |
-| `space` | `3` | Space between icon and track title |
+| `timeout`| 10 | Refresh cooldown |
+| `max_length` | 30 | Maximum lentgh of title. Text will be ellipsized if longer. |
+| `space` | 3 | Space between icon and track title |

--- a/cpu-widget/README.md
+++ b/cpu-widget/README.md
@@ -28,8 +28,8 @@ It is possible to customize widget by providing a table with all or some of the 
 | `step_width` | 2 | Width of the step |
 | `step_spacing` | 1 | Space size between steps |
 | `color` | `beautiful.fg_normal` | Color of the graph |
-| `enable_kill_button` | `false` | Show button which kills the process |
-| `process_info_max_length` | `-1` | Truncate the process information. Some processes may have a very long list of parameters which won't fit in the screen, this options allows to truncate it to the given length. |
+| `enable_kill_button` | false | Show button which kills the process |
+| `process_info_max_length` | -1 | Truncate the process information. Some processes may have a very long list of parameters which won't fit in the screen, this options allows to truncate it to the given length. |
 | `timeout` | 1 | How often in seconds the widget refreshes |
 
 ### Example

--- a/docker-widget/README.md
+++ b/docker-widget/README.md
@@ -16,7 +16,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `icon` | `./docker-widget/icons/docker.svg` | Path to the icon |
-| `number_of_containers` | `-1` | Number of last created containers to show |
+| `number_of_containers` | -1 | Number of last created containers to show |
 | `executable_name` | `docker` | Name of the executable to use, defaults to `docker` |
 | `max_widget_width` | 270 | Maximum width of the widget before the text breaks |
 

--- a/fs-widget/README.md
+++ b/fs-widget/README.md
@@ -10,7 +10,7 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `mounts` | `{'/'}` | Table with mounts to monitor, check the output from a `df` command for available options (column 'Mounted on') |
+| `mounts` | `{ '/' }` | Table with mounts to monitor, check the output from a `df` command for available options (column `Mounted on`) |
 | `timeout` | 60 | How often in seconds the widget refreshes |
 
 ## Installation

--- a/github-activity-widget/README.md
+++ b/github-activity-widget/README.md
@@ -15,7 +15,7 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `icon` | `github.png` from the widget sources | Widget icon displayed on the wibar |
-| `username` | Required | Your GitHub username |
+| `username` | Required | GitHub username |
 | `number_of_events` | 10 | Number of events to display in the list |
 
 ## Installation

--- a/github-activity-widget/README.md
+++ b/github-activity-widget/README.md
@@ -14,8 +14,8 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `icon` | github.png from the widget sources | Widget icon displayed on the wibar |
-| `username` | your username | Required parameter |
+| `icon` | `github.png` from the widget sources | Widget icon displayed on the wibar |
+| `username` | Required | Your GitHub username |
 | `number_of_events` | 10 | Number of events to display in the list |
 
 ## Installation

--- a/github-contributions-widget/README.md
+++ b/github-contributions-widget/README.md
@@ -15,10 +15,10 @@ It is possible to customize the widget by providing a table with all or some of 
 | Name | Default | Description |
 |---|---|---|
 | `username` | `streetturtle` | GitHub username |
-| `days` | `365` | Number of days in the past, more days - wider the widget |
+| `days` | 365 | Number of days in the past, more days - wider the widget |
 | `color_of_empty_cells` | Theme's default | Color of the days with no contributions |
-| `with_border` | `true` | Should the graph contains border or not |
-| `margin_top` | `1` | Top margin |
+| `with_border` | true | Should the graph contains border or not |
+| `margin_top` | 1 | Top margin |
 | `theme` | `standard` | Color theme of the graph, see below |
 
 _Note:_ widget height is 21px (7 rows of 3x3 cells). So it would look nice on the wibar of 22-24px height.

--- a/github-prs-widget/README.md
+++ b/github-prs-widget/README.md
@@ -21,7 +21,7 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `reviewer` | Required | github user login |
+| `reviewer` | Required | GitHub username |
 
 ## Installation
 

--- a/gitlab-widget/README.md
+++ b/gitlab-widget/README.md
@@ -21,8 +21,8 @@ It is possible to customize widget by providing a table with all or some of the 
 | Name | Default | Description |
 |---|---|---|
 | `icon` | `./icons/gitlab-icon.svg` | Path to the icon |
-| `host` | Required | e.g _https://gitlab.yourcompany.com_ |
-| `access_token` | Required | e.g _h2v531iYASDz6McxYk4A_ |
+| `host` | Required | e.g. `https://gitlab.yourcompany.com` |
+| `access_token` | Required | e.g. `h2v531iYASDz6McxYk4A` |
 | `timeout` | 60 | How often in seconds the widget should be refreshed |
 
 _Note:_

--- a/jira-widget/README.md
+++ b/jira-widget/README.md
@@ -18,7 +18,7 @@ It is possible to customize widget by providing a table with all or some of the 
 
 | Name | Default | Description |
 |---|---|---|
-| `host` | Required | Ex: _http://jira.tmnt.com_ |
+| `host` | Required | e.g. `http://jira.tmnt.com` |
 | `query` | `jql=assignee=currentuser() AND resolution=Unresolved` | JQL query |
 | `icon` | `~/.config/awesome/awesome-wm-widgets/jira-widget/jira-mark-gradient-blue.svg` | Path to the icon |
 | `timeout` | 600 | How often in seconds the widget refreshes |

--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -53,13 +53,13 @@ Then
 | Name | Default | Description |
 |---|---|---|
 | `icon` | `power.svg` | If used as widget - the path to the widget's icon |
-| `icon_size` | `40` | Size of the icon |
-| `icon_margin` | `16` | Margin around the icon |
+| `icon_size` | 40 | Size of the icon |
+| `icon_margin` | 16 | Margin around the icon |
 | `bg_color` |  `beautiful.bg_normal` | The color the background of the |
 | `accent_color` | `beautiful.bg_focus` | The color of the buttons |
 | `text_color` | `beautiful.fg_normal` | The color of text |
 | `label_color` | `beautiful.fg_normal` | The color of the button's label |
-| `phrases` | `{'Goodbye!'}` | The table with phrase(s) to show, if more than one provided, the phrase is chosen randomly. Leave empty (`{}`) to hide the phrase |
+| `phrases` | `{ 'Goodbye!' }` | The table with phrase(s) to show, if more than one provided, the phrase is chosen randomly. Leave empty (`{}`) to hide the phrase |
 | `onlogout` | `function() awesome.quit() end` | Function which is called when the logout button is pressed |
 | `onlock` | `function() awful.spawn.with_shell("systemctl suspend") end` | Function which is called when the lock button is pressed |
 | `onreboot` | `function() awful.spawn.with_shell("reboot") end` | Function which is called when the reboot button is pressed |

--- a/mpdarc-widget/README.md
+++ b/mpdarc-widget/README.md
@@ -4,7 +4,7 @@ Music Player Daemon widget by @raphaelfournier.
 
 # Prerequisite
 
-Install `mpd` (Music Player Daemon itself) and `mpc` (Music Player Client - program for controlling mpd), both should be available in repo, e.g for Ubuntu:
+Install `mpd` (Music Player Daemon itself) and `mpc` (Music Player Client - program for controlling mpd), both should be available in repo, e.g. for Ubuntu:
 
 ```bash
 sudo apt-get install mpd mpc

--- a/mpris-widget/README.md
+++ b/mpris-widget/README.md
@@ -4,7 +4,7 @@ Music Player Info widget cy @mgabs
 
 # Prerequisite
 
-Install `playerctl` (mpris implementation), should be available in repo, e.g for Ubuntu:
+Install `playerctl` (mpris implementation), should be available in repo, e.g. for Ubuntu:
 
 ```bash
 sudo apt-get install playerctl

--- a/pactl-widget/README.md
+++ b/pactl-widget/README.md
@@ -46,10 +46,10 @@ the following config parameters:
 | Name | Default | Description |
 |---|---|---|
 | `mixer_cmd` | `pavucontrol` | command to run on middle click (e.g. a mixer program) |
-| `step` | `5` | How much the volume is raised or lowered at once (in %) |
+| `step` | 5 | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
 | `device` | `@DEFAULT_SINK@` | Select the device name to control |
-| `tooltip` | `false` | Display volume level in a tooltip when the mouse cursor hovers the widget |
+| `tooltip` | false | Display volume level in a tooltip when the mouse cursor hovers the widget |
 
 For more details on parameters depending on the chosen widget type, please
 refer to the original Volume widget.

--- a/ram-widget/README.md
+++ b/ram-widget/README.md
@@ -15,10 +15,10 @@ It is possible to customize widget by providing a table with all or some of the 
 | `color_used` | `beautiful.bg_urgent` | Color for used RAM |
 | `color_free` | `beautiful.fg_normal` | Color for free RAM |
 | `color_buf`  | `beautiful.border_color_active` | Color for buffers/cache |
-| `widget_height` | `25` | Height of the widget |
-| `widget_width` | `25` | Width of the widget |
-| `widget_show_buf`  | `false` | Whether to display buffers/cache separately in the tray widget. If `false`, buffers/cache are considered free RAM. |
-| `timeout`    | 1 | How often (in seconds) the widget refreshes |
+| `widget_height` | 25 | Height of the widget |
+| `widget_width` | 25 | Width of the widget |
+| `widget_show_buf`  | false | Whether to display buffers/cache separately in the tray widget. If `false`, buffers/cache are considered free RAM. |
+| `timeout`    | 1 | How often in seconds the widget refreshes |
 
 ## Installation
 

--- a/spotify-widget/README.md
+++ b/spotify-widget/README.md
@@ -29,10 +29,10 @@ It is possible to customize widget by providing a table with all or some of the 
 | `play_icon` | `/usr/share/icons/Arc/actions/24/player_play.png` | Play icon |
 | `pause_icon` | `/usr/share/icons/Arc/actions/24/player_pause.png` | Pause icon |
 | `font` | `Play 9`| Font |
-| `dim_when_paused` | `false` | Decrease the widget opacity if spotify is paused |
-| `dim_opacity` | `0.2` | Widget's opacity when dimmed, `dim_when_paused` should be set to `true` |
-| `max_length` | `15` | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
-| `show_tooltip` | `true` | Show tooltip on hover with information about the playing song |
+| `dim_when_paused` | false | Decrease the widget opacity if spotify is paused |
+| `dim_opacity` | 0.2 | Widget's opacity when dimmed, `dim_when_paused` should be set to true |
+| `max_length` | 15 | Maximum lentgh of artist and title names. Text will be ellipsized if longer. |
+| `show_tooltip` | true | Show tooltip on hover with information about the playing song |
 | `timeout` | 1 | How often in seconds the widget refreshes |
 | `sp_bin` | `sp` | Path to the `sp` binary. Required if `sp` is not in environment PATH. |
 

--- a/stackoverflow-widget/README.md
+++ b/stackoverflow-widget/README.md
@@ -12,7 +12,7 @@ It is possible to customize widget by providing a table with all or some of the 
 |---|---|---|
 | `icon`| `/.config/awesome/awesome-wm-widgets/stackoverflow-widget/so-icon.svg` | Path to the icon |
 | `limit` | 5 | Number of items to show in the widget |
-| `tagged` | awesome-wm | Tag, or comma-separated tags |
+| `tagged` | `awesome-wm` | Tag, or comma-separated tags |
 | `timeout` | 300 | How often in seconds the widget refreshes |
 
 ## Installation

--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -57,7 +57,7 @@ It is possible to customize the widget by providing a table with all or some of 
 | Name | Default | Description |
 |---|---|---|
 | `mixer_cmd` | `pavucontrol` | command to run on middle click (e.g. a mixer program) |
-| `step` | `5` | How much the volume is raised or lowered at once (in %) |
+| `step` | 5 | How much the volume is raised or lowered at once (in %) |
 | `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
 | `device` | `pulse` | Select the device name to control |
 
@@ -98,11 +98,11 @@ _Note:_ if you are changing icons, the folder should contain following .svg imag
 |---|---|---|
 | `main_color` | `beautiful.fg_normal` | Color of the bar |
 | `mute_color` | `beautiful.fg_urgent` | Color of the bar when mute |
-| `bg_color` | `'#ffffff11'` | Color of the bar's background |
-| `width` | `50` | The bar width |
-| `margins` | `10` | Top and bottom margins (if your wibar is 22 px high, bar will be 2 px = 22 - 2*10) |
-| `shape` | `'bar'` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |
-| `with_icon` | `true` | Show volume icon|
+| `bg_color` | `#ffffff11` | Color of the bar's background |
+| `width` | 50 | The bar width |
+| `margins` | 10 | Top and bottom margins (if your wibar is 22 px high, bar will be 2 px = 22 - 2*10) |
+| `shape` | `bar` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |
+| `with_icon` | true | Show volume icon|
 
 _Note:_ I didn't figure out how does the `forced_height` property of progressbar widget work (maybe it doesn't work at all), thus there is a workaround with margins.
 
@@ -112,8 +112,8 @@ _Note:_ I didn't figure out how does the `forced_height` property of progressbar
 |---|---|---|
 | `main_color` | `beautiful.fg_normal` | Color of the bar |
 | `mute_color` | `beautiful.fg_urgent` | Color of the bar when mute |
-| `bg_color` | `'#ffffff11'` | Color of the bar's background |
-| `width` | `10` | The bar width |
-| `margins` | `20` | Top and bottom margins (if your wibar is 22 px high, bar will be 2 px = 22 - 2*10) |
-| `shape` | `'bar'` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |
-| `with_icon` | `true` | Show volume icon| 
+| `bg_color` | `#ffffff11` | Color of the bar's background |
+| `width` | 10 | The bar width |
+| `margins` | 20 | Top and bottom margins (if your wibar is 22 px high, bar will be 2 px = 22 - 2*10) |
+| `shape` | `bar` | [gears.shape](https://awesomewm.org/doc/api/libraries/gears.shape.html), could be `octogon`, `hexagon`, `powerline`, etc |
+| `with_icon` | true | Show volume icon| 

--- a/weather-widget/README.md
+++ b/weather-widget/README.md
@@ -29,11 +29,11 @@ It is possible to customize widget by providing a table with all or some of the 
 | api_key | Required | Get it [here](https://openweathermap.org/appid) |
 | font_name | `beautiful.font:gsub("%s%d+$", "")` | **Name** of the font to use e.g. 'Play' |
 | both_units_widget | false | Show temperature in both units - '28°C (83°F) |
-| units | metric | `metric` for celsius, `imperial` for fahrenheit |
+| units | `metric` | `metric` for celsius, `imperial` for fahrenheit |
 | show_hourly_forecast | false | Show hourly forecase section |
 | time_format_12h |false | 12 or 24 hour format (13:00 - default or 1pm) |
 | show_daily_forecast | false | Show daily forecast section |
-| icon_pack_name | weather-underground-icons | Name of the icon pack, could be `weather-underground-icon` or `VitalyGorbachev` or create your own, more details below |
+| icon_pack_name | `weather-underground-icons` | Name of the icon pack, could be `weather-underground-icon` or `VitalyGorbachev` or create your own, more details below |
 | icons_extension | `.png` | File extension of icons in the pack |
 | timeout | 120 | How often in seconds the widget refreshes |
 

--- a/word-clock-widget/README.md
+++ b/word-clock-widget/README.md
@@ -13,9 +13,9 @@ It is possible to customize widget by providing a table with all or some of the 
 | main_color | `beautiful.fg_normal` | Color of the word on odd position |
 | accent_color | `beautiful.fg_urgent` | Color of the word on even position |
 | font | `beautiful.font` | Font (`Play 20`) |
-| is_human_readable | `false` | _nine fifteen_ or _fifteen past nine_ | 
-| military_time | `false` | 12 or 24 time format |
-| with_spaces | `false` | Separate words with spaces |
+| is_human_readable | false | _nine fifteen_ or _fifteen past nine_ | 
+| military_time | false | 12 or 24 time format |
+| with_spaces | false | Separate words with spaces |
 
 ## Installation
 


### PR DESCRIPTION
I noticed a lot of inconsistencies in the documentation, mainly formatting, as well as some typos.

In tables, I'm using `single line code blocks` for argument values that have to be put between quotation marks, and no coding blocks for numbers and boolean values, since those don't need quotation marks.