### PR TITLE
volume-widget: added arguments, fixed colors for light themes

### DIFF
--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -73,6 +73,8 @@ It is possible to customize the widget by providing a table with all or some of 
 | `mixctrl`     | `Master`        | Select the mixer name to control                                                                                                      |
 | `value_type`  | `-M`            | Select how the volume is increased/ decreased (intended for `-M`/ `-R` parameters). See `man amixer` for additional info              |
 
+Note: If unmuting or toggling using the default amixer command does not work, this command may work: `pactl set-sink-mute [card] toggle`
+
 Depends on the chosen widget type add parameters from the corresponding section below:
 
 #### `icon` parameters

--- a/volume-widget/README.md
+++ b/volume-widget/README.md
@@ -36,7 +36,15 @@ s.mytasklist, -- Middle widget
         },
 ```
 
-Note that widget uses following command the get the current volume: `amixer -D pulse sget Master`, so please make sure that it works for you, otherwise you need to set parameter `device = 'default'`.
+Note that the widget uses following command to get the current volume: `amixer -c 1 -D pulse sget Master`, so please make sure that it works for you, otherwise you need to set some parameters by entering this command in the terminal:
+
+Command output:
+- Some data of a mixer: Override all parameters you've changed
+- Error `Invalid card number`: Change parameter `-c`/ `card`
+- Error `Mixer attach pulse error: No such file or directory`: Change parameter `-D`/ `device`
+- Error `Unable to find simple control 'Master',0`: Change parameter `mixctrl`
+
+Note: `amixer[ -c ...][ -D ...]` returns a list of Mixers for the selected card/ device. omitting `-D` falls back to `default`.
 
 ### Shortcuts
 
@@ -54,20 +62,24 @@ It is possible to customize the widget by providing a table with all or some of 
 
 ### Generic parameter
 
-| Name | Default | Description |
-|---|---|---|
-| `mixer_cmd` | `pavucontrol` | command to run on middle click (e.g. a mixer program) |
-| `step` | 5 | How much the volume is raised or lowered at once (in %) |
-| `widget_type`| `icon_and_text`| Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc` |
-| `device` | `pulse` | Select the device name to control |
+| Name          | Default         | Description                                                                                                                           |
+|---------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `mixer_cmd`   | `pavucontrol`   | command to run on middle click (e.g. a mixer program)                                                                                 |
+| `toggle_cmd`  | *nil*           | Use custom command instead of `amixer ... toggle` because [amixer's unmute option seems to be broken](https://superuser.com/a/822085) |
+| `step`        | 5               | How much the volume is raised or lowered at once (in %)                                                                               |
+| `widget_type` | `icon_and_text` | Widget type, one of `horizontal_bar`, `vertical_bar`, `icon`, `icon_and_text`, `arc`                                                  |
+| `card`        | 1               | Select the card name to control                                                                                                       |
+| `device`      | `pulse`         | Select the device name to control                                                                                                     |
+| `mixctrl`     | `Master`        | Select the mixer name to control                                                                                                      |
+| `value_type`  | `-M`            | Select how the volume is increased/ decreased (intended for `-M`/ `-R` parameters). See `man amixer` for additional info              |
 
 Depends on the chosen widget type add parameters from the corresponding section below:
 
 #### `icon` parameters
 
-| Name | Default | Description |
-|---|---|---|
-| `icon_dir`| `./icons`| Path to the folder with icons | 
+| Name       | Default              | Description                                   |
+|------------|----------------------|-----------------------------------------------|
+| `icon_dir` | `[widget_dir]/icons` | Path to the folder with icons (absolute path) |
 
 _Note:_ if you are changing icons, the folder should contain following .svg images: 
  - audio-volume-high-symbolic
@@ -77,10 +89,10 @@ _Note:_ if you are changing icons, the folder should contain following .svg imag
 
 #### `icon_and_text` parameters
 
-| Name | Default | Description |
-|---|---|---|
-| `icon_dir`| `./icons`| Path to the folder with icons | 
-| `font` | `beautiful.font` | Font name and size, like `Play 12` |
+| Name       | Default              | Description                                   |
+|------------|----------------------|-----------------------------------------------|
+| `icon_dir` | `[widget_dir]/icons` | Path to the folder with icons (absolute path) | 
+| `font`     | `beautiful.font`     | Font name and size, like `Play 12`            |
 
 #### `arc` parameters
 

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -214,7 +214,7 @@ local function worker(user_args)
         if toggle_cmd == nil then
             spawn.easy_async(TOG_VOLUME_CMD(card, device, mixctrl), function(stdout) update_graphic(volume.widget, stdout) end)
         else
-            spawn.easy_async(toggle_cmd, function(stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixctrl, value_type), function(stdout) update_graphic(volume.widget, stdout) end) end)
+            spawn.easy_async(toggle_cmd, function(_stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixctrl, value_type), function(stdout) update_graphic(volume.widget, stdout) end) end)
         end
     end
 

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -17,10 +17,10 @@ local utils = require("awesome-wm-widgets.volume-widget.utils")
 
 
 local LIST_DEVICES_CMD = [[sh -c "pacmd list-sinks; pacmd list-sources"]]
-local function GET_VOLUME_CMD(card, device, mixer) return 'amixer -c '..card..' -D '..device..' sget '..mixer end
-local function INC_VOLUME_CMD(card, device, mixer, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixer..' '..value_type..' '..step..'%+' end
-local function DEC_VOLUME_CMD(card, device, mixer, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixer..' '..value_type..' '..step..'%-' end
-local function TOG_VOLUME_CMD(card, device, mixer) return 'amixer -c '..card..' -D '..device..' sset '..mixer..' toggle' end
+local function GET_VOLUME_CMD(card, device, mixctrl) return 'amixer -c '..card..' -D '..device..' sget '..mixctrl end
+local function INC_VOLUME_CMD(card, device, mixctrl, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' '..value_type..' '..step..'%+' end
+local function DEC_VOLUME_CMD(card, device, mixctrl, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' '..value_type..' '..step..'%-' end
+local function TOG_VOLUME_CMD(card, device, mixctrl) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' toggle' end
 
 
 local widget_types = {
@@ -169,7 +169,7 @@ local function worker(user_args)
     local step = args.step or 5
     local card = args.card or 1
     local device = args.device or 'pulse'
-    local mixer = args.mixer or 'Master'
+    local mixctrl = args.mixctrl or 'Master'
     local value_type = args.value_type or '-M'
     local toggle_cmd = args.toggle_cmd or nil
 
@@ -190,18 +190,18 @@ local function worker(user_args)
     end
 
     function volume:inc(s)
-        spawn.easy_async(INC_VOLUME_CMD(card, device, mixer, value_type, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
+        spawn.easy_async(INC_VOLUME_CMD(card, device, mixctrl, value_type, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:dec(s)
-        spawn.easy_async(DEC_VOLUME_CMD(card, device, mixer, value_type, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
+        spawn.easy_async(DEC_VOLUME_CMD(card, device, mixctrl, value_type, s or step), function(stdout) update_graphic(volume.widget, stdout) end)
     end
 
     function volume:toggle()
         if toggle_cmd == nil then
-            spawn.easy_async(TOG_VOLUME_CMD(card, device, mixer), function(stdout) update_graphic(volume.widget, stdout) end)
+            spawn.easy_async(TOG_VOLUME_CMD(card, device, mixctrl), function(stdout) update_graphic(volume.widget, stdout) end)
         else
-            spawn.easy_async(toggle_cmd, function(stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixer), function(stdout) update_graphic(volume.widget, stdout) end) end)
+            spawn.easy_async(toggle_cmd, function(stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixctrl), function(stdout) update_graphic(volume.widget, stdout) end) end)
         end
     end
 
@@ -228,7 +228,7 @@ local function worker(user_args)
             )
     )
 
-    watch(GET_VOLUME_CMD(card, device, mixer), refresh_rate, update_graphic, volume.widget)
+    watch(GET_VOLUME_CMD(card, device, mixctrl), refresh_rate, update_graphic, volume.widget)
 
     return volume.widget
 end

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -17,7 +17,7 @@ local utils = require("awesome-wm-widgets.volume-widget.utils")
 
 
 local LIST_DEVICES_CMD = [[sh -c "pacmd list-sinks; pacmd list-sources"]]
-local function GET_VOLUME_CMD(card, device, mixctrl) return 'amixer -c '..card..' -D '..device..' sget '..mixctrl end
+local function GET_VOLUME_CMD(card, device, mixctrl, value_type) return 'amixer -c '..card..' -D '..device..' sget '..mixctrl..' '..value_type  end
 local function INC_VOLUME_CMD(card, device, mixctrl, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' '..value_type..' '..step..'%+' end
 local function DEC_VOLUME_CMD(card, device, mixctrl, value_type, step) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' '..value_type..' '..step..'%-' end
 local function TOG_VOLUME_CMD(card, device, mixctrl) return 'amixer -c '..card..' -D '..device..' sset '..mixctrl..' toggle' end
@@ -214,7 +214,7 @@ local function worker(user_args)
         if toggle_cmd == nil then
             spawn.easy_async(TOG_VOLUME_CMD(card, device, mixctrl), function(stdout) update_graphic(volume.widget, stdout) end)
         else
-            spawn.easy_async(toggle_cmd, function(stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixctrl), function(stdout) update_graphic(volume.widget, stdout) end) end)
+            spawn.easy_async(toggle_cmd, function(stdout) spawn.easy_async(GET_VOLUME_CMD(card, device, mixctrl, value_type), function(stdout) update_graphic(volume.widget, stdout) end) end)
         end
     end
 
@@ -241,7 +241,7 @@ local function worker(user_args)
             )
     )
 
-    watch(GET_VOLUME_CMD(card, device, mixctrl), refresh_rate, update_graphic, volume.widget)
+    watch(GET_VOLUME_CMD(card, device, mixctrl, value_type), refresh_rate, update_graphic, volume.widget)
 
     return volume.widget
 end

--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -36,6 +36,7 @@ local rows  = { layout = wibox.layout.fixed.vertical }
 
 local popup = awful.popup{
     bg = beautiful.bg_normal,
+    fg = beautiful.fg_normal,
     ontop = true,
     visible = false,
     shape = gears.shape.rounded_rect,
@@ -60,12 +61,12 @@ local function build_rows(devices, on_checkbox_click, device_type)
 
         local checkbox = wibox.widget {
             checked = device.is_default,
-            color = beautiful.bg_normal,
+            color = beautiful.fg_normal,
             paddings = 2,
             shape = gears.shape.circle,
             forced_width = 20,
             forced_height = 20,
-            check_color = beautiful.fg_urgent,
+            check_color = beautiful.fg_normal,
             widget = wibox.widget.checkbox
         }
 
@@ -99,11 +100,22 @@ local function build_rows(devices, on_checkbox_click, device_type)
                 layout = wibox.container.margin
             },
             bg = beautiful.bg_normal,
+            fg = beautiful.fg_normal,
             widget = wibox.container.background
         }
 
-        row:connect_signal("mouse::enter", function(c) c:set_bg(beautiful.bg_focus) end)
-        row:connect_signal("mouse::leave", function(c) c:set_bg(beautiful.bg_normal) end)
+        row:connect_signal("mouse::enter", function(c)
+            checkbox:set_color(beautiful.fg_focus)
+            checkbox:set_check_color(beautiful.fg_focus)
+            c:set_fg(beautiful.fg_focus)
+            c:set_bg(beautiful.bg_focus)
+        end)
+        row:connect_signal("mouse::leave", function(c)
+            checkbox:set_color(beautiful.fg_normal)
+            checkbox:set_check_color(beautiful.fg_normal)
+            c:set_fg(beautiful.fg_normal)
+            c:set_bg(beautiful.bg_normal)
+        end)
 
         local old_cursor, old_wibox
         row:connect_signal("mouse::enter", function()
@@ -138,6 +150,7 @@ local function build_header_row(text)
             widget = wibox.widget.textbox
         },
         bg = beautiful.bg_normal,
+        fg = beautiful.fg_normal,
         widget = wibox.container.background
     }
 end


### PR DESCRIPTION
#### added options
- card: `amixer -c [card]`
  - multiple cards support
- value_type: `amixer -M` or `-R`
  - from the command help:
    ```
    -R,--raw-volume Use the raw value (default)
    -M,--mapped-volume Use the mapped volume
    ```
    no idea how this actually works, but lowering the volume using `-R` takes big steps at first and then they become smaller.
    when using `-M` the steps stay constant (5% relative to 100%/ 0dB) 
- mixctrl: (`amixer [args] [command] [mixctrl] [command ct'd]`)
  - multiple mixers support
  - fixes #396 (used the same key for compatibility with the awesome rc.lua of those users who applied the code suggested in the issue) 
- toggle_cmd: overrides `amixer ...` command for (un)muting
  - allows users to replace the broken `amixer sset [mixer] toggle` command which uses `amixer sset [mixer] [un]mute` with anything like `pactl set-sink-mute 0 toggle` which worked for me

#### fixed colors for light themes

only for volume, i might create additional PRs for other widgets i use (see ).

tested with themes:
- gtk (with little patches to be a complete light theme)
- default

#### fixed get volume cmd

see [#df4dd6d](https://github.com/streetturtle/awesome-wm-widgets/pull/416/commits/df4dd6d0f6f51f89e43631ff35e5204534fe931a)
-M was forgotten so amixer used -R as fallback

#### todo

please let me know if the changes are ok, i will then update the readme before merging.