### PR TITLE
calendar-widget: added option to show week numbers, possible fix for #316

### DIFF
--- a/calendar-widget/README.md
+++ b/calendar-widget/README.md
@@ -7,12 +7,13 @@ Calendar widget for Awesome WM - slightly improved version of the `wibox.widget.
 
 ### Customization
 
-| Name | Default | Description |
-|---|---|---|
-| theme        | `naughty` | The theme to use          |
-| placement    | `top`     | The position of the popup |
-| radius       |  8        | The popup radius          |
-| start_sunday | false  | Start the week on Sunday  |
+| Name         | Default   | Description                         |
+|--------------|-----------|-------------------------------------|
+| theme        | `naughty` | The theme to use                    |
+| placement    | `top`     | The position of the popup           |
+| radius       | 8         | The popup radius                    |
+| start_sunday | false     | Start the week on Sunday            |
+| week_numbers | false     | Show ISO week numbers (Mon = first) |
 
  - themes:
 

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -98,6 +98,7 @@ local function worker(user_args)
     local next_month_button = args.next_month_button or 4
     local previous_month_button = args.previous_month_button or 5
     local start_sunday = args.start_sunday or false
+    local week_numbers = args.week_numbers or false
 
     local styles = {}
     local function rounded_shape(size)
@@ -156,7 +157,7 @@ local function worker(user_args)
         -- Change bg color for weekends
         local d = { year = date.year, month = (date.month or 1), day = (date.day or 1) }
         local weekday = tonumber(os.date('%w', os.time(d)))
-        local default_bg = (weekday == 0 or weekday == 6)
+        local default_bg = (flag == 'focus' or flag == 'normal') and (weekday == 0 or weekday == 6)
             and calendar_themes[theme].weekend_day_bg
             or calendar_themes[theme].bg
         local ret = wibox.widget {
@@ -173,7 +174,7 @@ local function worker(user_args)
             shape_border_color = props.border_color or '#000000',
             shape_border_width = props.border_width or 0,
             fg = props.fg_color or calendar_themes[theme].fg,
-            bg = props.bg_color or default_bg,
+            bg = default_bg,
             widget = wibox.container.background
         }
 
@@ -186,6 +187,7 @@ local function worker(user_args)
         fn_embed = decorate_cell,
         long_weekdays = true,
         start_sunday = start_sunday,
+        week_numbers = week_numbers,
         widget = wibox.widget.calendar.month
     }
 

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -157,7 +157,7 @@ local function worker(user_args)
         -- Change bg color for weekends
         local d = { year = date.year, month = (date.month or 1), day = (date.day or 1) }
         local weekday = tonumber(os.date('%w', os.time(d)))
-        local default_bg = (weekday == 0 or weekday == 6)
+        local default_bg = (flag == 'focus' or flag == 'normal') and (weekday == 0 or weekday == 6)
             and calendar_themes[theme].weekend_day_bg
             or calendar_themes[theme].bg
         local ret = wibox.widget {
@@ -174,7 +174,7 @@ local function worker(user_args)
             shape_border_color = props.border_color or '#000000',
             shape_border_width = props.border_width or 0,
             fg = props.fg_color or calendar_themes[theme].fg,
-            bg = props.bg_color or default_bg,
+            bg = default_bg,
             widget = wibox.container.background
         }
 
@@ -187,6 +187,7 @@ local function worker(user_args)
         fn_embed = decorate_cell,
         long_weekdays = true,
         start_sunday = start_sunday,
+        week_numbers = week_numbers,
         widget = wibox.widget.calendar.month
     }
 


### PR DESCRIPTION
the problem should be, that the `decorate_all` (`fn_embed`) is called multiple times for multiple purposes:
1. flag=header|monthheader|weeknumber: background should stay normal
2. flag=weekday|normal|focus: background should stay normal until its weekend
3. flag=month: background should stay normal. and this is the line causing problems: https://github.com/awesomeWM/awesome/blob/aa8c7c6e27a20fa265d3f06c5dc3fe72cc5f021e/lib/wibox/widget/calendar.lua#L272

ive kind of fixed it but since i just know some lua basics, this might be not the best solution

possible fix for #316 