### PR TITLE
[batteryarc] Add support for reading multiple batteries in one batteryarc instance

### DIFF
--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -88,16 +88,28 @@ local function worker(user_args)
 
     local function update_widget(widget, stdout)
         local charge = 0
-        local status
+        local batteries = 0
+        local status = 'Unknown'
         for s in stdout:gmatch("[^\r\n]+") do
             local cur_status, charge_str, _ = string.match(s, '.+: ([%a%s]+), (%d?%d?%d)%%,?(.*)')
             if cur_status ~= nil and charge_str ~=nil then
                 local cur_charge = tonumber(charge_str)
-                if cur_charge > charge then
-                    status = cur_status
-                    charge = cur_charge
+                if cur_status ~= 'Unknown' then
+                    if status == 'Charging' or cur_status == 'Charging' then
+                        status = 'Charging'
+                    else
+                        status = cur_status
+                    end
+                    charge = charge + cur_charge
+                    batteries = batteries + 1
                 end
             end
+        end
+
+        if batteries > 0 then
+            charge = charge // batteries
+        else
+            charge = 0
         end
 
         widget.value = charge


### PR DESCRIPTION
For multiple batteries, each percentage gets added into "charge", and then divided by the number of batteries. Batteries with status "Unknown" don't get counted.

This way you can have a rough overall power indicator (it perhaps could be improved by reading the capacity of each battery, but that seems overkill).

I could make it a separate widget, or make it require a flag, if that would be preferable (this could be added to the other pull request about passing an id for which battery for the widget to read).