### PR TITLE
Fixed import instructions for pacman-widget

### DIFF
--- a/pacman-widget/README.md
+++ b/pacman-widget/README.md
@@ -15,7 +15,7 @@ The widget also uses the `checkupdates` script from the `pacman-contrib` package
 Clone the repo under **~/.config/awesome/** and add the following to **rc.lua**:
 
 ```lua
-local pacman_widget = require('pacman-widget.pacman')
+local pacman_widget = require('awesome-wm-widgets-pacman-widget.pacman')
 ...
 s.mytasklist, -- Middle widget
 	{ -- Right widgets


### PR DESCRIPTION
### Previous instructions:

`local pacman_widget = require('pacman-widget.pacman')`

### Fixed to:

`local pacman_widget = require('awesome-wm-widgets.pacman-widget.pacman')`