### PR TITLE
fix SI/IEC prefixes

### DIFF
--- a/fs-widget/fs-widget.lua
+++ b/fs-widget/fs-widget.lua
@@ -159,7 +159,7 @@ local function worker(user_args)
                         {
                             text = math.floor(disks[v].used / 1024 / 1024)
                                     .. '/'
-                                    .. math.floor(disks[v].size / 1024 / 1024) .. 'GB('
+                                    .. math.floor(disks[v].size / 1024 / 1024) .. 'GiB('
                                     .. math.floor(disks[v].perc) .. '%)',
                             widget = wibox.widget.textbox
                         },

--- a/net-speed-widget/net-speed.lua
+++ b/net-speed-widget/net-speed.lua
@@ -29,15 +29,15 @@ local function convert_to_h(bytes)
         dim = 'kb/s'
     elseif bits < 1000000000 then
         speed = bits/1000000
-        dim = 'mb/s'
+        dim = 'Mb/s'
     elseif bits < 1000000000000 then
         speed = bits/1000000000
-        dim = 'gb/s'
+        dim = 'Gb/s'
     else
         speed = tonumber(bits)
         dim = 'b/s'
     end
-    return math.floor(speed + 0.5) .. dim
+    return math.floor(speed + 0.5) .. ' ' .. dim
 end
 
 local function split(string_to_split, separator)


### PR DESCRIPTION
- lower `m` is milli, not mega
- lower `g` is unassigned
- capital `G` is 10⁹, `Gi` is 2³⁰

see https://en.wikipedia.org/wiki/Metric_prefix