### PR TITLE
 complete redesign of #417, working now (tm)

### DIFF
--- a/calendar-widget/README.md
+++ b/calendar-widget/README.md
@@ -7,12 +7,13 @@ Calendar widget for Awesome WM - slightly improved version of the `wibox.widget.
 
 ### Customization
 
-| Name | Default | Description |
-|---|---|---|
-| theme        | `naughty` | The theme to use          |
-| placement    | `top`     | The position of the popup |
-| radius       |  8        | The popup radius          |
-| start_sunday | false  | Start the week on Sunday  |
+| Name         | Default   | Description                         |
+|--------------|-----------|-------------------------------------|
+| theme        | `naughty` | The theme to use                    |
+| placement    | `top`     | The position of the popup           |
+| radius       | 8         | The popup radius                    |
+| start_sunday | false     | Start the week on Sunday            |
+| week_numbers | false     | Show ISO week numbers (Mon = first) |
 
  - themes:
 

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -70,10 +70,10 @@ local function worker(user_args)
             border = '#75715E'
         },
         naughty = {
-            bg = beautiful.notification_bg or beautiful.bg,
-            fg = beautiful.notification_fg or beautiful.fg,
-            focus_date_bg = beautiful.notification_fg or beautiful.fg,
-            focus_date_fg = beautiful.notification_bg or beautiful.bg,
+            bg = beautiful.notification_bg or beautiful.bg or beautiful.bg_normal,
+            fg = beautiful.notification_fg or beautiful.fg or beautiful.fg_normal,
+            focus_date_bg = beautiful.notification_fg or beautiful.fg or beautiful.fg_normal,
+            focus_date_fg = beautiful.notification_bg or beautiful.bg or beautiful.bg_normal,
             weekend_day_bg = beautiful.bg_focus,
             weekday_fg = beautiful.fg,
             header_fg = beautiful.fg,
@@ -98,6 +98,7 @@ local function worker(user_args)
     local next_month_button = args.next_month_button or 4
     local previous_month_button = args.previous_month_button or 5
     local start_sunday = args.start_sunday or false
+    local week_numbers = args.week_numbers or false
 
     local styles = {}
     local function rounded_shape(size)
@@ -154,11 +155,14 @@ local function worker(user_args)
             widget:set_markup(props.markup(widget:get_text()))
         end
         -- Change bg color for weekends
-        local d = { year = date.year, month = (date.month or 1), day = (date.day or 1) }
-        local weekday = tonumber(os.date('%w', os.time(d)))
-        local default_bg = (weekday == 0 or weekday == 6)
-            and calendar_themes[theme].weekend_day_bg
-            or calendar_themes[theme].bg
+        local default_bg
+        if (flag == "normal") then
+            local d = { year = date.year, month = (date.month or 1), day = (date.day or 1) }
+            local weekday = tonumber(os.date('%w', os.time(d)))
+            default_bg = (weekday == 0 or weekday == 6)
+                and calendar_themes[theme].weekend_day_bg
+                or calendar_themes[theme].bg
+        end
         local ret = wibox.widget {
             {
                 {
@@ -186,6 +190,7 @@ local function worker(user_args)
         fn_embed = decorate_cell,
         long_weekdays = true,
         start_sunday = start_sunday,
+        week_numbers = week_numbers,
         widget = wibox.widget.calendar.month
     }
 


### PR DESCRIPTION
fixed #426, reverts some changes in #417, week numbers still implemented

tested
- themes: gtk (naughty), all internal themes
- commented out [calendar.lua#R146-R151](https://github.com/streetturtle/awesome-wm-widgets/pull/427/files#diff-3b353f097c213fdeca54038e3547aceb95ded674754ea27f7c94bac5e5044ceeR146-R151) for testing to simulate #316 (normal test using naughty only)
- opened calendar popup,
  - 2023-11-23: start: week, today: week ,
  - 2023-10-23: start: weekend, today: workday,
  - 2023-07-23 start: weekend, today: weekend

please verify (or do better tests)

@xfzv does this work for you?