### PR TITLE
logout-menu: fixed widget button bg color, fixed rows fg color

### DIFF
--- a/logout-menu-widget/logout-menu.lua
+++ b/logout-menu-widget/logout-menu.lua
@@ -26,7 +26,7 @@ local logout_menu_widget = wibox.widget {
         layout = wibox.container.margin
     },
     shape = function(cr, width, height)
-    gears.shape.rounded_rect(cr, width, height, 4)
+        gears.shape.rounded_rect(cr, width, height, 4)
     end,
     widget = wibox.container.background,
 }
@@ -58,11 +58,11 @@ local function worker(user_args)
     local onpoweroff = args.onpoweroff or function() awful.spawn.with_shell("shutdown now") end
 
     local menu_items = {
-        { name = 'Log out', icon_name = 'log-out.svg', command = function () logout_menu_widget:set_bg('#00000000') onlogout() end },
-        { name = 'Lock', icon_name = 'lock.svg', command = function () logout_menu_widget:set_bg('#00000000') onlock() end },
-        { name = 'Reboot', icon_name = 'refresh-cw.svg', command = function () logout_menu_widget:set_bg('#00000000') onreboot() end },
-        { name = 'Suspend', icon_name = 'moon.svg', command = function () logout_menu_widget:set_bg('#00000000') onsuspend() end },
-        { name = 'Power off', icon_name = 'power.svg', command = function () logout_menu_widget:set_bg('#00000000') onpoweroff() end },
+        { name = 'Log out', icon_name = 'log-out.svg', command = onlogout },
+        { name = 'Lock', icon_name = 'lock.svg', command = onlock },
+        { name = 'Reboot', icon_name = 'refresh-cw.svg', command = onreboot },
+        { name = 'Suspend', icon_name = 'moon.svg', command = onsuspend },
+        { name = 'Power off', icon_name = 'power.svg', command = onpoweroff },
     }
 
     for _, item in ipairs(menu_items) do
@@ -109,6 +109,7 @@ local function worker(user_args)
 
         row:buttons(awful.util.table.join(awful.button({}, 1, function()
             popup.visible = not popup.visible
+            logout_menu_widget:set_bg('#00000000')
             item.command()
         end)))
 

--- a/logout-menu-widget/logout-menu.lua
+++ b/logout-menu-widget/logout-menu.lua
@@ -58,11 +58,11 @@ local function worker(user_args)
     local onpoweroff = args.onpoweroff or function() awful.spawn.with_shell("shutdown now") end
 
     local menu_items = {
-        { name = 'Log out', icon_name = 'log-out.svg', command = onlogout },
-        { name = 'Lock', icon_name = 'lock.svg', command = onlock },
-        { name = 'Reboot', icon_name = 'refresh-cw.svg', command = onreboot },
-        { name = 'Suspend', icon_name = 'moon.svg', command = onsuspend },
-        { name = 'Power off', icon_name = 'power.svg', command = onpoweroff },
+        { name = 'Log out', icon_name = 'log-out.svg', command = function () logout_menu_widget:set_bg('#00000000') onlogout() end },
+        { name = 'Lock', icon_name = 'lock.svg', command = function () logout_menu_widget:set_bg('#00000000') onlock() end },
+        { name = 'Reboot', icon_name = 'refresh-cw.svg', command = function () logout_menu_widget:set_bg('#00000000') onreboot() end },
+        { name = 'Suspend', icon_name = 'moon.svg', command = function () logout_menu_widget:set_bg('#00000000') onsuspend() end },
+        { name = 'Power off', icon_name = 'power.svg', command = function () logout_menu_widget:set_bg('#00000000') onpoweroff() end },
     }
 
     for _, item in ipairs(menu_items) do
@@ -86,12 +86,13 @@ local function worker(user_args)
                 margins = 8,
                 layout = wibox.container.margin
             },
+            fg = beautiful.fg_normal,
             bg = beautiful.bg_normal,
             widget = wibox.container.background
         }
 
-        row:connect_signal("mouse::enter", function(c) c:set_bg(beautiful.bg_focus) end)
-        row:connect_signal("mouse::leave", function(c) c:set_bg(beautiful.bg_normal) end)
+        row:connect_signal("mouse::enter", function(c) c:set_bg(beautiful.bg_focus) c:set_fg(beautiful.fg_focus) end)
+        row:connect_signal("mouse::leave", function(c) c:set_bg(beautiful.bg_normal) c:set_fg(beautiful.fg_normal) end)
 
         local old_cursor, old_wibox
         row:connect_signal("mouse::enter", function()


### PR DESCRIPTION
1. foreground colors of rows were not updated in light theme
   - expected behavior: text is readable
   - current behavior: text is always white (even with light themes)
2. background color of widget button stays active/ focused after clicking on one rows. not disturbing when logging out, shutting down or rebooting but when locking or suspending.
   - expected behavior: button background color is reset when an action is executed (a row is clicked on).
   - current behavior: button keeps active until the menu is opened and closed again (button background changes only when clicked on it).

this pr does not change any icon colors (they're still light/ grey). i'm not sure how to change them: either by
- duplicating the files, change the color in the svg (hard coded like it is now)
- keep the files, change the color with lua