### PR TITLE
fixed #434

### DIFF
--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -228,11 +228,13 @@ local function worker(user_args)
         if popup.visible then
             -- to faster render the calendar refresh it and just hide
             cal:set_date(nil) -- the new date is not set without removing the old one
-            cal:set_date(os.date('*t'))
             popup:set_widget(nil) -- just in case
-            popup:set_widget(cal)
-            popup.visible = not popup.visible
+            popup.visible = false
         else
+            -- apply it when the calendar is opened! - probably slower but fixes the issue that the
+            --  day is not updated when *opening* the popup (only when closing)
+            cal:set_date(os.date('*t'))
+            popup:set_widget(cal)
             if placement == 'top' then
                 awful.placement.top(popup, { margins = { top = 30 }, parent = awful.screen.focused() })
             elseif placement == 'top_right' then


### PR DESCRIPTION
(From the Issue:)
> When keeping the computer turned on over night, the current day/ today day is not updated. To update the day, the calendar popup has to be closed (which triggers the update, see [calendar.lua#L229-L234](https://github.com/streetturtle/awesome-wm-widgets/blob/2c58ef6fd1a19c49e39b87b915003bf78dbd429e/calendar-widget/calendar.lua#L229-L234)) and opened again.

I'm not sure if the lines 230 (where the calendars date is reset; `-- the new date is not set without removing the old one`) and 232 (where the calendar widget is reset; `-- just in case`) should be moved to the else case or stay where they are.
I haven't experienced any issues with the fix though