### PR TITLE
apt-widget icon-control

### DIFF
--- a/apt-widget/apt-widget.lua
+++ b/apt-widget/apt-widget.lua
@@ -99,6 +99,7 @@ local function worker(user_args)
 	local pointer = 0
 	local min_widgets = 5
 	local carousel = false
+    local icon_control = args.icon_control
 
 	local function rebuild_widget(containers, errors, _, _)
 		local to_update = {}
@@ -353,7 +354,7 @@ local function worker(user_args)
 	end)))
 
 	wibox_popup:connect_signal("mouse::leave", function()
-		if wibox_popup.visible then
+		if wibox_popup.visible and not icon_control then
 			wibox_popup.visible = false
 		end
 	end)


### PR DESCRIPTION
Hi. I am proposing a change in the apt-widget.lua code. As it is now the popup menu disappears when the pointer moves out of the popup area. If you wanted, for example, to complete some updates and watch the list shrink, you would have to hover over the popup. The moment your cursor leaves the popup area, it closes. I've added a variable called 'icon_control'. This variable can be set in the 'rc.lua' file as part of apt-widget. When set the popup does not close when you leave it with your mouse. The popup does close when the user clicks again on the icon. This is similar to the way that the file-system widget works. Of course if you leave it out of your config, the widget should still work. I was going to call the variable 'auto_close' but this would imply that the variable needed to be set for the old behavior to work, and I want it so that the old behavior is associated with no extra setting whatsoever. If this change is made, the readme file might need to be added to. This is a sort of feature request.