### PR TITLE
Allow setting up logout-popup-widget button keybindings and ignore case

### DIFF
--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -71,6 +71,7 @@ Then
 | `onreboot_key` | <kbd>r</kbd> | Keybinding to execute the reboot function |
 | `onsuspend_key` | <kbd>u</kbd> | Keybinding to execute the suspend function |
 | `onpoweroff_key` | <kbd>s</kbd> | Keybinding to execute the poweroff function |
+| `ignore_case` | true | Ignore if CAPS LOCK is enabled |
 
 Some color themes for inspiration:
 

--- a/logout-popup-widget/README.md
+++ b/logout-popup-widget/README.md
@@ -66,6 +66,11 @@ Then
 | `onreboot` | `function() awful.spawn.with_shell("reboot") end` | Function which is called when the reboot button is pressed |
 | `onsuspend` | `function() awful.spawn.with_shell("systemctl suspend") end` | Function which is called when the suspend button is pressed |
 | `onpoweroff` | `function() awful.spawn.with_shell("shutdown now") end` | Function which is called when the poweroff button is pressed |
+| `onlogout_key` | <kbd>l</kbd> | Keybinding to execute the logout function |
+| `onlock_key` | <kbd>k</kbd> | Keybinding to execute the lock function |
+| `onreboot_key` | <kbd>r</kbd> | Keybinding to execute the reboot function |
+| `onsuspend_key` | <kbd>u</kbd> | Keybinding to execute the suspend function |
+| `onpoweroff_key` | <kbd>s</kbd> | Keybinding to execute the poweroff function |
 
 Some color themes for inspiration:
 

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -90,15 +90,6 @@ local function launch(args)
 
     local ignore_case = args.ignore_case or true
 
-    if ignore_case then
-        onlogout_key = string.lower(onlogout_key)
-        onlock_key = string.lower(onlock_key)
-        onreboot_key = string.lower(onreboot_key)
-        onsuspend_key = string.lower(onsuspend_key)
-        onpoweroff_key = string.lower(onpoweroff_key)
-        all_keys = string.lower(all_keys)
-    end
-
     w:set_bg(bg_color)
     if #phrases > 0 then
         phrase_widget:set_markup(
@@ -162,6 +153,12 @@ local function launch(args)
             else
                 if ignore_case then
                     key = string.lower(key)
+                    onlogout_key = string.lower(onlogout_key)
+                    onlock_key = string.lower(onlock_key)
+                    onreboot_key = string.lower(onreboot_key)
+                    onsuspend_key = string.lower(onsuspend_key)
+                    onpoweroff_key = string.lower(onpoweroff_key)
+                    all_keys = string.lower(all_keys)
                 end
 
                 if key == onpoweroff_key then onpoweroff()

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -86,6 +86,18 @@ local function launch(args)
     local onreboot_key = args.onreboot_key or 'r'
     local onsuspend_key = args.onsuspend_key or 'u'
     local onpoweroff_key = args.onpoweroff_key or 's'
+    local all_keys = onlogout_key .. onlock_key .. onreboot_key .. onsuspend_key .. onpoweroff_key
+
+    local ignore_case = args.ignore_case or true
+
+    if ignore_case then
+        onlogout_key = string.lower(onlogout_key)
+        onlock_key = string.lower(onlock_key)
+        onreboot_key = string.lower(onreboot_key)
+        onsuspend_key = string.lower(onsuspend_key)
+        onpoweroff_key = string.lower(onpoweroff_key)
+        all_keys = string.lower(all_keys)
+    end
 
     w:set_bg(bg_color)
     if #phrases > 0 then
@@ -147,19 +159,23 @@ local function launch(args)
                 phrase_widget:set_text('')
                 capi.keygrabber.stop()
                 w.visible = false
-            elseif string.lower(key) == string.lower(onpoweroff_key) then onpoweroff()
-            elseif string.lower(key) == string.lower(onreboot_key) then onreboot()
-            elseif string.lower(key) == string.lower(onsuspend_key) then onsuspend()
-            elseif string.lower(key) == string.lower(onlock_key) then onlock()
-            elseif string.lower(key) == string.lower(onlogout_key) then onlogout()
-            end
+            else
+                if ignore_case then
+                    key = string.lower(key)
+                end
 
-            local all_keys = onlogout_key .. onlock_key .. onreboot_key .. onsuspend_key .. onpoweroff_key
+                if key == onpoweroff_key then onpoweroff()
+                elseif key == onreboot_key then onreboot()
+                elseif key == onsuspend_key then onsuspend()
+                elseif key == onlock_key then onlock()
+                elseif key == onlogout_key then onlogout()
+                end
 
-            if key == 'Escape' or string.match(string.lower(all_keys), string.lower(key)) then
-                phrase_widget:set_text('')
-                capi.keygrabber.stop()
-                w.visible = false
+                if string.match(all_keys, key) then
+                    phrase_widget:set_text('')
+                    capi.keygrabber.stop()
+                    w.visible = false
+                end
             end
         end
     end)

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -81,6 +81,12 @@ local function launch(args)
     local onsuspend = args.onsuspend or function() awful.spawn.with_shell("systemctl suspend") end
     local onpoweroff = args.onpoweroff or function() awful.spawn.with_shell("shutdown now") end
 
+    local onlogout_key = args.onlogout_key or 'l'
+    local onlock_key = args.onlock_key or 'k'
+    local onreboot_key = args.onreboot_key or 'r'
+    local onsuspend_key = args.onsuspend_key or 'u'
+    local onpoweroff_key = args.onpoweroff_key or 's'
+
     w:set_bg(bg_color)
     if #phrases > 0 then
         phrase_widget:set_markup(
@@ -92,15 +98,15 @@ local function launch(args)
             phrase_widget,
             {
                 {
-                    create_button('log-out', 'Log Out (l)',
+                    create_button('log-out', 'Log Out (' .. onlogout_key .. ')',
                         accent_color, label_color, onlogout, icon_size, icon_margin),
-                    create_button('lock', 'Lock (k)',
+                    create_button('lock', 'Lock (' .. onlock_key .. ')',
                         accent_color, label_color, onlock, icon_size, icon_margin),
-                    create_button('refresh-cw', 'Reboot (r)',
+                    create_button('refresh-cw', 'Reboot (' .. onreboot_key .. ')',
                         accent_color, label_color, onreboot, icon_size, icon_margin),
-                    create_button('moon', 'Suspend (u)',
+                    create_button('moon', 'Suspend (' .. onsuspend_key .. ')',
                         accent_color, label_color, onsuspend, icon_size, icon_margin),
-                    create_button('power', 'Power Off (s)',
+                    create_button('power', 'Power Off (' .. onpoweroff_key .. ')',
                         accent_color, label_color, onpoweroff, icon_size, icon_margin),
                     id = 'buttons',
                     spacing = 8,
@@ -141,14 +147,16 @@ local function launch(args)
                 phrase_widget:set_text('')
                 capi.keygrabber.stop()
                 w.visible = false
-            elseif key == 's' then onpoweroff()
-            elseif key == 'r' then onreboot()
-            elseif key == 'u' then onsuspend()
-            elseif key == 'k' then onlock()
-            elseif key == 'l' then onlogout()
+            elseif string.lower(key) == string.lower(onpoweroff_key) then onpoweroff()
+            elseif string.lower(key) == string.lower(onreboot_key) then onreboot()
+            elseif string.lower(key) == string.lower(onsuspend_key) then onsuspend()
+            elseif string.lower(key) == string.lower(onlock_key) then onlock()
+            elseif string.lower(key) == string.lower(onlogout_key) then onlogout()
             end
 
-            if key == 'Escape' or string.match("srukl", key) then
+            local all_keys = onlogout_key .. onlock_key .. onreboot_key .. onsuspend_key .. onpoweroff_key
+
+            if key == 'Escape' or string.match(all_keys, key) then
                 phrase_widget:set_text('')
                 capi.keygrabber.stop()
                 w.visible = false

--- a/logout-popup-widget/logout-popup.lua
+++ b/logout-popup-widget/logout-popup.lua
@@ -156,7 +156,7 @@ local function launch(args)
 
             local all_keys = onlogout_key .. onlock_key .. onreboot_key .. onsuspend_key .. onpoweroff_key
 
-            if key == 'Escape' or string.match(all_keys, key) then
+            if key == 'Escape' or string.match(string.lower(all_keys), string.lower(key)) then
                 phrase_widget:set_text('')
                 capi.keygrabber.stop()
                 w.visible = false


### PR DESCRIPTION
Added the ability to set the keybindings for each button in the logout-popup-widget and to choose whether it will ignore CAPS LOCK or not.