### PR TITLE
feat(calendar): add auto hide functionality

### DIFF
--- a/calendar-widget/README.md
+++ b/calendar-widget/README.md
@@ -14,6 +14,8 @@ Calendar widget for Awesome WM - slightly improved version of the `wibox.widget.
 | radius       | 8         | The popup radius                    |
 | start_sunday | false     | Start the week on Sunday            |
 | week_numbers | false     | Show ISO week numbers (Mon = first) |
+| auto_hide    | false     | Auto hide the popup after timeout   |
+| timeout      | 2         | Auto hide timeout length         |
 
  - themes:
 

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -243,6 +243,7 @@ local function worker(user_args)
     function calendar_widget.toggle()
 
         if popup.visible then
+	    auto_hide_timer:stop()
             -- to faster render the calendar refresh it and just hide
             cal:set_date(nil) -- the new date is not set without removing the old one
             cal:set_date(os.date('*t'))

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -203,6 +203,23 @@ local function worker(user_args)
         border_color = calendar_themes[theme].border,
         widget = cal
     }
+    
+	local auto_hide_timer = gears.timer({
+		timeout = user_args.timeout or 2,
+		single_shot = true,
+		callback = function()
+			calendar_widget.toggle()
+		end,
+	})
+
+	popup:connect_signal("mouse::leave", function()
+        if user_args.auto_hide then 
+		    auto_hide_timer:again()
+        end
+	end)
+	popup:connect_signal("mouse::enter", function()
+		auto_hide_timer:stop()
+	end)
 
     popup:buttons(
             awful.util.table.join(
@@ -250,6 +267,10 @@ local function worker(user_args)
             end
 
             popup.visible = true
+            if user_args.auto_hide then
+                auto_hide_timer:start()
+            end
+
 
         end
     end

--- a/calendar-widget/calendar.lua
+++ b/calendar-widget/calendar.lua
@@ -243,7 +243,7 @@ local function worker(user_args)
     function calendar_widget.toggle()
 
         if popup.visible then
-	    auto_hide_timer:stop()
+            auto_hide_timer:stop()
             -- to faster render the calendar refresh it and just hide
             cal:set_date(nil) -- the new date is not set without removing the old one
             cal:set_date(os.date('*t'))


### PR DESCRIPTION
Just started using your widget library and it felt odd to me you had to manually close the calendar widget. As such I quickly threw this together to support a configurable auto-hide functionality based on the interaction with the popup itself.

Still really new to Lua and AwesomeWM so happy to tweak as desired if there's interest in this.