### PR TITLE
feat: show daily forecast

### DIFF
--- a/weather-api-widget/README.md
+++ b/weather-api-widget/README.md
@@ -18,6 +18,7 @@ following config parameters:
 | units | `metric` | `metric` for celsius, `imperial` for fahrenheit |
 | icon_pack_name | `weather-underground-icons` | Name of the icon pack, could be `weather-underground-icon` or `VitalyGorbachev` or create your own, more details below |
 | icons_extension | `.png` | File extension of icons in the pack |
+| show_forecast | false | Show forecast for next three days |
 | timeout | 120 | How often in seconds the widget refreshes |
 
 ### Icons:


### PR DESCRIPTION
Each day is also including hourly forecast, but this PR lays the groundwork by talking to the right endpoint.

Instead of day and night values (like in the old weather-widget) I'm showing min and max temperature as forecasted here.