### PR TITLE
docs: describe workaround for coordinates

### DIFF
--- a/weather-api-widget/README.md
+++ b/weather-api-widget/README.md
@@ -3,6 +3,7 @@
 ![Current Weather popup](./popup.png)
 
 The widget consists of one section:
+
 - current weather, including humidity, wind speed, UV index
 
 ## Customization
@@ -23,12 +24,17 @@ following config parameters:
 | show_hourly_forecast | false | Show hourly forecast section |
 | timeout | 120 | How often in seconds the widget refreshes |
 
-### Icons:
+In [#461](https://github.com/streetturtle/awesome-wm-widgets/issues/461) it was
+reported that some machines replace the dot with a comma in coordinates. If
+this happens to you, wrap the numbers in quotation marks, e.g.
+`{"46.204400", "6.143200"}`.
+
+### Icons
 
 The widget comes with two predefined icon packs:
 
- - [weather-underground-icons](https://github.com/manifestinteractive/weather-underground-icons)
- - [VitalyGorbachev](https://www.flaticon.com/authors/vitaly-gorbachev)
+- [weather-underground-icons](https://github.com/manifestinteractive/weather-underground-icons)
+- [VitalyGorbachev](https://www.flaticon.com/authors/vitaly-gorbachev)
 
 To add your custom icons, create a folder with the pack name under `/icons` and
 use the folder name in widget's config. There should be 18 icons, preferably


### PR DESCRIPTION
This should not happen but in case it does I describe a potential solution here.

Markdownlint highlighted some warnings that I addressed while touching this file.