### PR TITLE
Fix battery string formatting

### DIFF
--- a/battery-widget/battery.lua
+++ b/battery-widget/battery.lua
@@ -163,7 +163,7 @@ local function worker(user_args)
         charge = charge / capacity
 
         if show_current_level then
-            level_widget.text = string.format('%d%%', charge)
+            level_widget.text = string.format('%.0f%%', charge)
         end
 
         if (charge >= 1 and charge < 15) then


### PR DESCRIPTION
In modern versions of Lua, formatting a float with `%d` is not allowed (see https://stackoverflow.com/questions/31577104/lua-format-string-cant-format-float-as-decimal-d-as-of-5-3). This PR fixes it by using `%.0f`. This technically changes the behavior because instead of truncating, it rounds the number, but there is no significant difference in my opinion.