### PR TITLE
fix: spawn.easy_async function missing callback

### DIFF
--- a/volume-widget/volume.lua
+++ b/volume-widget/volume.lua
@@ -272,7 +272,7 @@ local function worker(user_args)
 
 	function volume:mixer()
 		if mixer_cmd then
-			spawn.easy_async(mixer_cmd)
+			spawn.easy_async(mixer_cmd, function(stdout, stderr, exitreason, exitcode) end)
 		end
 	end
 


### PR DESCRIPTION
added a callback function to spawn.easy_async, as expects a callback function

Fixes: #446 