### PR TITLE
fix: wrong method call - get_volume_and_mute instead of get_volume

### DIFF
--- a/wpctl-widget/volume.lua
+++ b/wpctl-widget/volume.lua
@@ -222,7 +222,7 @@ local function worker(user_args)
         awful.tooltip {
             objects        = { volume.widget },
             timer_function = function()
-                local vol,mut = wpctl.get_volume(device)
+                local vol,mut = wpctl.get_volume_and_mute(device)
                 return vol .. "%"
             end,
         }


### PR DESCRIPTION
Replaces in line 225

local vol,mut = wpctl.get_volume(device)
with
local vol,mut = wpctl.get_volume_and_mute(device)

because get_volume does not exist anymore.