### PR TITLE
brightness: use standard brightnessctl args instead of faffing about with shell magic

### DIFF
--- a/brightness-widget/brightness.lua
+++ b/brightness-widget/brightness.lua
@@ -60,7 +60,7 @@ local function worker(user_args)
         inc_brightness_cmd = 'xbacklight -inc ' .. step
         dec_brightness_cmd = 'xbacklight -dec ' .. step
     elseif program == 'brightnessctl' then
-        get_brightness_cmd = "sh -c 'brightnessctl -m | cut -d, -f4 | tr -d %'"
+        get_brightness_cmd = "brightnessctl get -P"
         set_brightness_cmd = "brightnessctl set %d%%" -- <level>
         inc_brightness_cmd = "brightnessctl set +" .. step .. "%"
         dec_brightness_cmd = "brightnessctl set " .. step .. "-%"


### PR DESCRIPTION
Ran into this while debugging an unrelated issue. But this looks cleaner and should be more future proof.